### PR TITLE
ngModel and CKEditor data value

### DIFF
--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -165,7 +165,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	}
 
 	// Implementing the ControlValueAccessor interface (only when binding to ngModel).
-	writeValue( value: string ): void {
+	writeValue( value: string | null ): void {
 		// If already initialized
 		if ( this.editorInstance ) {
 			this.editorInstance.setData( value != null ? value : '' );

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -166,13 +166,17 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 
 	// Implementing the ControlValueAccessor interface (only when binding to ngModel).
 	writeValue( value: string | null ): void {
+		// If a null was received, the textarea content needs to be empty
+		if ( value == null ) {
+			value = '';
+		}
 		// If already initialized
 		if ( this.editorInstance ) {
-			this.editorInstance.setData( value != null ? value : '' );
+			this.editorInstance.setData( value );
 		}
 		// If not, wait for it to be ready; store the data.
 		else {
-			this.data = value != null ? value : '';
+			this.data = value;
 		}
 	}
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -168,11 +168,11 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	writeValue( value: string ): void {
 		// If already initialized
 		if ( this.editorInstance ) {
-			this.editorInstance.setData( value != null ? value : "" );
+			this.editorInstance.setData( value != null ? value : '' );
 		}
 		// If not, wait for it to be ready; store the data.
 		else {
-			this.data = value != null ? value : "";
+			this.data = value != null ? value : '';
 		}
 	}
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -168,11 +168,11 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	writeValue( value: string ): void {
 		// If already initialized
 		if ( this.editorInstance ) {
-			this.editorInstance.setData( value );
+			this.editorInstance.setData( value != null ? value : "" );
 		}
 		// If not, wait for it to be ready; store the data.
 		else {
-			this.data = value;
+			this.data = value != null ? value : "";
 		}
 	}
 


### PR DESCRIPTION
When ngModel is used, the writeValue method is called first time with a null value, and CKEditor will display a null instead of a empty string. This pull request makes it so that it only displays a empty string when the content is null.