### PR TITLE
Changed angular peer dependencies versions to the `>=5.0.0` range.

### DIFF
--- a/src/ckeditor/package.json
+++ b/src/ckeditor/package.json
@@ -3,9 +3,9 @@
   "description": "CKEditor 5 component for Angular 2+.",
   "version": "0.0.1",
   "peerDependencies": {
-    "@angular/core": "^6.0.0",
-    "@angular/common": "^6.0.0",
-    "@angular/forms": "^6.0.0"
+    "@angular/core": ">=5.0.0",
+    "@angular/common": ">=5.0.0",
+    "@angular/forms": ">=5.0.0"
   },
   "author": "CKSource (http://cksource.com/)",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Changed angular peer dependencies versions to the `>=5.0.0` range. Closes #39.

---

### Additional information

Note that integrations with Angular 4.x.x and lower throw an error.
