### PR TITLE
Improve discoverability of developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Official [CKEditor 5](https://ckeditor.com/ckeditor-5/) rich text editor component for Angular 2+.
 
-## Documentation
+## [Documentation](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) 📖
 
 See the [Angular 2+ component](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) article in the [CKEditor 5 documentation](https://ckeditor.com/docs/ckeditor5/latest).
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Official [CKEditor 5](https://ckeditor.com/ckeditor-5/) rich text editor compone
 
 See the [Angular 2+ component](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) article in the [CKEditor 5 documentation](https://ckeditor.com/docs/ckeditor5/latest).
 
+### Table of content:
+1. [Quick start](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#quick-start)
+1. [Integration with `ngModel`](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#integration-with-ngmodel)
+1. [Supported `@Input` properties](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#supported-input-properties)
+1. [Supported `@Output` properties](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#supported-output-properties)
+1. [Styling](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#styling)
+1. [Localization](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#localization)
+
 ## Contributing
 
 After cloning this repository, install necessary dependencies:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Official [CKEditor 5](https://ckeditor.com/ckeditor-5/) rich text editor component for Angular 2+.
 
-## [Documentation](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) 📖
+## [Developer Documentation](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) 📖
 
 See the [Angular 2+ component](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) article in the [CKEditor 5 documentation](https://ckeditor.com/docs/ckeditor5/latest).
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,14 @@ Official [CKEditor 5](https://ckeditor.com/ckeditor-5/) rich text editor compone
 
 ## [Developer Documentation](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) 📖
 
-See the [Angular 2+ component](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) article in the [CKEditor 5 documentation](https://ckeditor.com/docs/ckeditor5/latest).
+See the ["Rich text editor component for Angular 2+"](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) guide in the [CKEditor 5 documentation](https://ckeditor.com/docs/ckeditor5/latest) to learn more:
 
-### Table of content:
-1. [Quick start](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#quick-start)
-1. [Integration with `ngModel`](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#integration-with-ngmodel)
-1. [Supported `@Input` properties](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#supported-input-properties)
-1. [Supported `@Output` properties](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#supported-output-properties)
-1. [Styling](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#styling)
-1. [Localization](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#localization)
+* [Quick start](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#quick-start)
+* [Integration with `ngModel`](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#integration-with-ngmodel)
+* [Supported `@Input` properties](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#supported-input-properties)
+* [Supported `@Output` properties](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#supported-output-properties)
+* [Styling](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#styling)
+* [Localization](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#localization)
 
 ## Contributing
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Improved the discoverability of developer docs. Closes #63.

---

### Additional information

* Added ToC to the readme.
* Added link and icon to the Documentation header.
