### PR TITLE
Changed the default file to the `index.ts` that reexports module, component and typings

### DIFF
--- a/src/ckeditor/ckeditor.ts
+++ b/src/ckeditor/ckeditor.ts
@@ -1,4 +1,9 @@
 /**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
  * Basic typings for the CKEditor5 elements.
  */
 export namespace CKEditor5 {

--- a/src/ckeditor/index.spec.ts
+++ b/src/ckeditor/index.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import * as ClassicEditorBuild from '@ckeditor/ckeditor5-build-classic';
+
+import {
+	CKEditorComponent,
+	CKEditorModule,
+	CKEditor5
+} from './index';
+
+describe( 'index.ts - the entry file', () => {
+	let component: CKEditorComponent;
+	let fixture: ComponentFixture<CKEditorComponent>;
+
+	beforeEach( async( () => {
+		TestBed.configureTestingModule( {
+			declarations: [ CKEditorComponent ]
+		} )
+			.compileComponents();
+	} ) );
+
+	beforeEach( () => {
+		fixture = TestBed.createComponent( CKEditorComponent );
+		component = fixture.componentInstance;
+		component.editor = ClassicEditorBuild;
+	} );
+
+	it( 'should expose the CKEditorComponent', () => {
+		fixture.detectChanges();
+
+		return wait().then( () => {
+			const componentInstance: CKEditor5.Editor = component.editorInstance!;
+
+			expect( componentInstance ).toBeTruthy();
+		} );
+	} );
+
+	it( 'should expose the CKEditorModule', () => {
+		expect( CKEditorModule ).toBeTruthy();
+	} );
+} );
+
+function wait( time?: number ) {
+	return new Promise( res => {
+		setTimeout( res, time );
+	} );
+}

--- a/src/ckeditor/index.ts
+++ b/src/ckeditor/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+export * from './ckeditor';
+export * from './ckeditor.component';
+export * from './ckeditor.module';

--- a/src/ckeditor/package.json
+++ b/src/ckeditor/package.json
@@ -32,7 +32,7 @@
   },
   "ngPackage": {
     "lib": {
-      "entryFile": "./ckeditor.module.ts"
+      "entryFile": "./index.ts"
     },
     "whitelistedNonPeerDependencies": [
       "."


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Reexported `CKEditorModule`, `CKEditorComponent` and typings from the package entry point. Closes #66.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
