### PR TITLE
Fix problem with initializing data during the collaboration

### DIFF
--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -107,13 +107,28 @@ describe( 'CKEditorComponent', () => {
 		} );
 
 		it( 'should not be set using `editor.setData()` during the initialization step', () => {
-			class EventEmitter {
-				on() {}
+			class EditorMock {
+				model = {
+					document: new EventEmitter()
+				};
+
+				editing = {
+					view: {
+						document: new EventEmitter()
+					}
+				};
+
+				setData = createSpy();
+
+				static create() {
+					return Promise.resolve( new this() );
+				}
+
+				destroy() {}
 			}
 
-			interface Spy {
-				(): void;
-				called: boolean;
+			class EventEmitter {
+				on() {}
 			}
 
 			function createSpy() {
@@ -126,22 +141,9 @@ describe( 'CKEditorComponent', () => {
 				return spy;
 			}
 
-			class EditorMock {
-				public model = {
-					document: new EventEmitter()
-				};
-				public editing = {
-					view: {
-						document: new EventEmitter()
-					}
-				};
-				public setData = createSpy();
-
-				static create() {
-					return Promise.resolve( new this() );
-				}
-
-				destroy() {}
+			interface Spy {
+				(): void;
+				called: boolean;
 			}
 
 			component.editor = ( EditorMock as any );

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -107,6 +107,10 @@ describe( 'CKEditorComponent', () => {
 		} );
 
 		it( 'should not be set using `editor.setData()` during the initialization step', () => {
+			class EventEmitter {
+				on() {}
+			}
+
 			class EditorMock {
 				model = {
 					document: new EventEmitter()
@@ -125,10 +129,6 @@ describe( 'CKEditorComponent', () => {
 				}
 
 				destroy() {}
-			}
-
-			class EventEmitter {
-				on() {}
 			}
 
 			function createSpy() {

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -83,8 +83,9 @@ describe( 'CKEditorComponent', () => {
 		} );
 
 		it( 'should be configurable at the start of the component', () => {
-			fixture.detectChanges();
 			component.data = 'foo';
+
+			fixture.detectChanges();
 
 			return wait().then( () => {
 				expect( component.data ).toEqual( 'foo' );
@@ -93,8 +94,8 @@ describe( 'CKEditorComponent', () => {
 		} );
 
 		it( 'should be writeable by ControlValueAccessor', () => {
-			fixture.detectChanges();
 			component.writeValue( 'foo' );
+			fixture.detectChanges();
 
 			return wait().then( () => {
 				expect( component.editorInstance!.getData() ).toEqual( '<p>foo</p>' );

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -144,6 +144,11 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	 */
 	private cvaOnTouched?: () => void;
 
+	/**
+	 * Reference to the source element used by the editor.
+	 */
+	private editorElement?: HTMLElement;
+
 	constructor( elementRef: ElementRef, ngZone: NgZone ) {
 		this.ngZone = ngZone;
 		this.elementRef = elementRef;
@@ -179,6 +184,12 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		// If not, wait for it to be ready; store the data.
 		else {
 			this.data = value;
+
+			// If the editor element is already available, then update its content.
+			// If the ngModel is used then the editor element should be updated directly here.
+			if ( this.editorElement ) {
+				this.editorElement.innerHTML = this.data;
+			}
 		}
 	}
 
@@ -210,23 +221,17 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	 */
 	private createEditor(): Promise<any> {
 		const element = document.createElement( this.tagName );
+		this.editorElement = element;
 
 		// Do not use the `editor.setData()` here because of the issue in the collaboration mode (#6).
 		// Instead set data to the element on which the editor will be later initialized.
 		element.innerHTML = this.data;
-
-		const oldData = this.data;
 
 		this.elementRef.nativeElement.appendChild( element );
 
 		return this.editor!.create( element, this.config )
 			.then( editor => {
 				this.editorInstance = editor;
-
-				// Update data if it has changed in the meantime.
-				if ( this.data !== oldData ) {
-					this.editorInstance.setData( this.data );
-				}
 
 				if ( this.initialIsDisabled ) {
 					editor.isReadOnly = this.initialIsDisabled;

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -211,13 +211,15 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	private createEditor(): Promise<any> {
 		const element = document.createElement( this.tagName );
 
+		// Do not use the `editor.setData()` here because of the issue in the collaboration mode (#6).
+		// Instead set data to the element on which the editor will be later initialized.
+		element.innerHTML = this.data;
+
 		this.elementRef.nativeElement.appendChild( element );
 
 		return this.editor!.create( element, this.config )
 			.then( editor => {
 				this.editorInstance = editor;
-
-				editor.setData( this.data );
 
 				if ( this.initialIsDisabled ) {
 					editor.isReadOnly = this.initialIsDisabled;

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -215,11 +215,18 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		// Instead set data to the element on which the editor will be later initialized.
 		element.innerHTML = this.data;
 
+		const oldData = this.data;
+
 		this.elementRef.nativeElement.appendChild( element );
 
 		return this.editor!.create( element, this.config )
 			.then( editor => {
 				this.editorInstance = editor;
+
+				// Update data if it has changed in the meantime.
+				if ( this.data !== oldData ) {
+					this.editorInstance.setData( this.data );
+				}
 
 				if ( this.initialIsDisabled ) {
 					editor.isReadOnly = this.initialIsDisabled;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed problem with initializing data in the editor during the collaboration. After the second client connects the data is taken from the first client. Closes #75.

### Additional information
While reviewing, please follow this guide: https://github.com/ckeditor/ckeditor5-angular/issues/6