### PR TITLE
Remove usages of Angular 2+

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor 5 component for Angular 2+** – https://github.com/ckeditor/ckeditor5-angular <br>
+**CKEditor 5 component for Angular** – https://github.com/ckeditor/ckeditor5-angular <br>
 Copyright (c) 2003-2019, [CKSource](http://cksource.com) Frederico Knabben. All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See the ["Rich text editor component for Angular"](https://ckeditor.com/docs/cke
 
 ## Supported Angular versions
 
-The integration can be used together with Angular at version 5.0.0 and highers. It is an implication of Angular metadata produced for this package by the Angular builder. Note that the `package.json` used in the main repository isn't published on NPM (the production one is present in `src/ckeditor/package.json`), so there are only a few peer dependencies to `@angular/core >= 5.0.0`, `@angular/common >= 5.0.0` and `@angular/forms >= 5.0.0` required by this package.
+The integration can be used together with Angular at version `5.0.0` and higher. It is an implication of Angular metadata produced for this package by the Angular builder. Note that the `package.json` used in the main repository isn't published on NPM (the production one is present in `src/ckeditor/package.json`), so there are only a few peer dependencies to `@angular/core >= 5.0.0`, `@angular/common >= 5.0.0` and `@angular/forms >= 5.0.0` required by this package.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Dependency Status](https://david-dm.org/ckeditor/ckeditor5-angular/status.svg)](https://david-dm.org/ckeditor/ckeditor5-angular)
 [![devDependency Status](https://david-dm.org/ckeditor/ckeditor5-angular/dev-status.svg)](https://david-dm.org/ckeditor/ckeditor5-angular?type=dev)
 
-Official [CKEditor 5](https://ckeditor.com/ckeditor-5/) rich text editor component for Angular 2+.
+Official [CKEditor 5](https://ckeditor.com/ckeditor-5/) rich text editor component for Angular 2+ (Angular 5+).
 
 ## [Developer Documentation](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) 📖
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ See the ["Rich text editor component for Angular"](https://ckeditor.com/docs/cke
 * [Styling](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#styling)
 * [Localization](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#localization)
 
+## Supported Angular versions
+
+The integration can be used together with Angular at version 5.0.0 and highers. It is an implication of Angular metadata produced for this package by the Angular builder. Note that the `package.json` used in the main repository isn't published on NPM (the production one is present in `src/ckeditor/package.json`), so there are only a few peer dependencies to `@angular/core >= 5.0.0`, `@angular/common >= 5.0.0` and `@angular/forms >= 5.0.0` required by this package.
+
 ## Contributing
 
 After cloning this repository, install necessary dependencies:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CKEditor 5 rich text editor component for Angular 2+
+# CKEditor 5 rich text editor component for Angular
 
 [![Join the chat at https://gitter.im/ckeditor/ckeditor5](https://badges.gitter.im/ckeditor/ckeditor5.svg)](https://gitter.im/ckeditor/ckeditor5?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-angular.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-angular)
@@ -9,11 +9,11 @@
 [![Dependency Status](https://david-dm.org/ckeditor/ckeditor5-angular/status.svg)](https://david-dm.org/ckeditor/ckeditor5-angular)
 [![devDependency Status](https://david-dm.org/ckeditor/ckeditor5-angular/dev-status.svg)](https://david-dm.org/ckeditor/ckeditor5-angular?type=dev)
 
-Official [CKEditor 5](https://ckeditor.com/ckeditor-5/) rich text editor component for Angular 2+ (Angular 5+).
+Official [CKEditor 5](https://ckeditor.com/ckeditor-5/) rich text editor component for Angular 5+.
 
 ## [Developer Documentation](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) 📖
 
-See the ["Rich text editor component for Angular 2+"](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) guide in the [CKEditor 5 documentation](https://ckeditor.com/docs/ckeditor5/latest) to learn more:
+See the ["Rich text editor component for Angular"](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html) guide in the [CKEditor 5 documentation](https://ckeditor.com/docs/ckeditor5/latest) to learn more:
 
 * [Quick start](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#quick-start)
 * [Integration with `ngModel`](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html#integration-with-ngmodel)
@@ -34,7 +34,7 @@ npm install
 
 This repository contains the following code:
 
-* `./src/ckeditor` contains the CKEditor component,
+* `./src/ckeditor` contains the implementation of `<ckeditor>` component,
 * `./src/app` is a demo application using the component.
 
 **Note:** The [npm package](https://www.npmjs.com/package/@ckeditor/ckeditor5-angular) contains a [packaged component](#packaging-the-component) only.

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -15,7 +15,7 @@ describe( 'app', () => {
 		it( 'should display header message', async() => {
 			const content = await page.getHeaderContent();
 
-			expect( content ).toEqual( 'CKEditor integration with Angular' );
+			expect( content ).toEqual( 'CKEditor 5 integration with Angular' );
 		} );
 
 		it( 'should display editor with set content', async() => {

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -15,7 +15,7 @@ describe( 'app', () => {
 		it( 'should display header message', async() => {
 			const content = await page.getHeaderContent();
 
-			expect( content ).toEqual( 'CKEditor integration with Angular 2+' );
+			expect( content ).toEqual( 'CKEditor integration with Angular' );
 		} );
 
 		it( 'should display editor with set content', async() => {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "__IMPORTANT__": "This file won't be published. See `src/ckeditor/package.json`, which will be published on NPM.",
   "name": "@ckeditor/ckeditor5-angular",
   "version": "1.1.0",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@ckeditor/ckeditor5-angular",
   "version": "1.1.0",
   "private": true,
-  "description": "Official Angular 2+ component for CKEditor 5 – the best browser-based rich text editor.",
+  "description": "Official Angular component for CKEditor 5 – the best browser-based rich text editor.",
   "scripts": {
     "start": "ng serve --open",
     "build": "ng build --prod",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<h1>CKEditor integration with Angular 2+</h1>
+<h1>CKEditor 5 integration with Angular</h1>
 
 <nav>
 	<ul>

--- a/src/app/simple-usage/simple-usage.component.spec.ts
+++ b/src/app/simple-usage/simple-usage.component.spec.ts
@@ -58,7 +58,7 @@ describe( 'SimpleUsageComponent', () => {
 	} );
 
 	describe( 'data', () => {
-		it( 'should set initial data on the CKEditor component', () => {
+		it( 'should set initial data on the `<ckeditor>` component', () => {
 			expect( ckeditorComponent.data )
 				.toContain( '<p>Getting used to an entirely different culture can be challenging.' );
 		} );

--- a/src/ckeditor/package.json
+++ b/src/ckeditor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ckeditor/ckeditor5-angular",
   "version": "0.0.1",
-  "description": "Official Angular 2+ component for CKEditor 5 – the best browser-based rich text editor.",
+  "description": "Official Angular component for CKEditor 5 – the best browser-based rich text editor.",
   "keywords": [
     "wysiwyg",
     "rich text",
@@ -11,6 +11,7 @@
     "editing",
     "angular",
     "angular2",
+    "angular 5",
     "ng",
     "component",
     "ckeditor",

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>CKEditor 5 component for Angular 2+ demo</title>
+  <title>CKEditor 5 component for Angular demo</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Removed usages of `Angular 2+` from code and readmes; added information about supported Angular versions. Closes #95.
