### PR TITLE
Fixed typings for Watchdog to make old TS compilers happy

### DIFF
--- a/src/ckeditor/ckeditor.ts
+++ b/src/ckeditor/ckeditor.ts
@@ -102,7 +102,7 @@ export namespace CKEditor5 {
 	export interface Watchdog<T> {
 		setCreator( creator: ( ...args: any[] ) => Promise<T> ): void;
 		setDestructor( destructor: ( item: T ) => Promise<void> ): void;
-		on( event: string, callback: ( ...args: any ) => any ): void;
+		on( event: string, callback: ( ...args: any[] ) => any ): void;
 		destroy(): Promise<void>;
 		create( ...args: any[] ): Promise<void>;
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed typings for `Watchdog` to make old TS compilers happy. Closes #172.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
