### PR TITLE
Updated required node version to 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: node_js
 services:
 - xvfb
 node_js:
-- '10'
+- '14'
 cache:
 - node_modules
 before_install:

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "webpack-cli": "^4.0.0"
   },
   "engines": {
-    "node": ">=8.0.0",
+    "node": ">=14.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",


### PR DESCRIPTION
Other: Updated the required version of Node.js to 14. See ckeditor/ckeditor5#10972.

MAJOR BREAKING CHANGE: Upgraded the minimal versions of Node.js to `14.0.0` due to the end of LTS.