### PR TITLE
Fixed bug: changes in data input property are not reflected

### DIFF
--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -7,6 +7,7 @@ import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { CKEditorComponent } from './ckeditor.component';
 import * as CKSource from '../../ckeditor/build/cksource';
+import { SimpleChange } from '@angular/core';
 
 describe( 'CKEditorComponent', () => {
 	let component: CKEditorComponent;
@@ -189,6 +190,19 @@ describe( 'CKEditorComponent', () => {
 				await waitCycle();
 
 				expect( component.editorInstance!.getData() ).toEqual( '<p>foo</p>' );
+			} );
+
+			it( 'should update editor instance data when \'data\' input property changes', async () => {
+				const updatedText = '<p>Updated data</p>';
+
+				component.ngOnChanges( {
+					data: new SimpleChange( '', updatedText, false )
+				} );
+
+				fixture.detectChanges();
+				await waitCycle();
+
+				expect( component.editorInstance!.getData() ).toEqual( updatedText );
 			} );
 		} );
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -10,7 +10,7 @@ declare global {
 }
 
 import type {
-	AfterViewInit, OnDestroy } from '@angular/core';
+	AfterViewInit, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import {
 	Component,
 	Input,
@@ -65,7 +65,7 @@ export interface ChangeEvent {
 		}
 	]
 } )
-export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValueAccessor {
+export class CKEditorComponent implements AfterViewInit, OnDestroy, OnChanges, ControlValueAccessor {
 	/**
 	 * The reference to the DOM element created by the component.
 	 */
@@ -235,6 +235,16 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 			}
 		} else {
 			console.warn( 'Cannot find the "CKEDITOR_VERSION" in the "window" scope.' );
+		}
+	}
+
+	/**
+	 *Implementing the OnChanges interface.
+	 *Whenever 'data' property changes we need to update the contents of the editor.
+	*/
+	public ngOnChanges( changes: SimpleChanges ): void {
+		if ( Object.prototype.hasOwnProperty.call( changes, 'data' ) && changes.data && !changes.data.isFirstChange() ) {
+			this.writeValue( changes.data.currentValue );
 		}
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Added support for `OnChanges` lifecycle hook that updates editor content when data-bound property of a component changes. Closes #215.

---

--- _Original description_ ---

Closes #215 

Fixed the bug outline in the issue #215 where the angular component does not update the editor contents on changed data property.

Implemented OnChanges interface that checks if the data property has been changed. If it has been, then we write a new value to the editor.

Lastly, added one more unit test case to assert the fix.

My first pull request, tell me if something has to be changed!