### PR TITLE
Added `editorWatchdogConfig` property that allows defining configuration for the EditorWatchdog

### DIFF
--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -425,6 +425,15 @@ describe( 'CKEditorComponent', () => {
 		} );
 
 		describe( 'in case of the editor watchdog integration', () => {
+			it( 'should use the provided configuration', async () => {
+				component.watchdogConfig = { crashNumberLimit: 678 };
+
+				fixture.detectChanges();
+
+				expect( ( component as any ).editorWatchdog ).not.toBeUndefined();
+				expect( ( component as any ).editorWatchdog._crashNumberLimit ).toEqual( 678 );
+			} );
+
 			it( 'should restart the editor when the editor crashes', async () => {
 				window.onerror = null;
 

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -426,7 +426,7 @@ describe( 'CKEditorComponent', () => {
 
 		describe( 'in case of the editor watchdog integration', () => {
 			it( 'should use the provided configuration', async () => {
-				component.watchdogConfig = { crashNumberLimit: 678 };
+				component.editorWatchdogConfig = { crashNumberLimit: 678 };
 
 				fixture.detectChanges();
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -16,6 +16,7 @@ import {
 } from '@angular/core';
 
 import EditorWatchdog from '@ckeditor/ckeditor5-watchdog/src/editorwatchdog';
+import WatchdogConfig from '@ckeditor/ckeditor5-watchdog/src/watchdog';
 import { first } from 'rxjs/operators';
 
 import uid from './uid';
@@ -95,6 +96,11 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, OnChanges, C
 	 * The context watchdog.
 	 */
 	@Input() public watchdog?: CKEditor5.ContextWatchdog;
+
+	/**
+	 * Config for the EditorWatchdog.
+	 */
+	@Input() public watchdogConfig?: WatchdogConfig;
 
 	/**
 	 * Allows disabling the two-way data binding mechanism. Disabling it can boost performance for large documents.
@@ -385,7 +391,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, OnChanges, C
 			} );
 		} else {
 			// In the other case create the watchdog by hand to keep the editor running.
-			const editorWatchdog: CKEditor5.EditorWatchdog = new EditorWatchdog( this.editor );
+			const editorWatchdog: CKEditor5.EditorWatchdog = new EditorWatchdog( this.editor, this.watchdogConfig );
 
 			editorWatchdog.setCreator( creator );
 			editorWatchdog.setDestructor( destructor );

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -100,7 +100,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, OnChanges, C
 	/**
 	 * Config for the EditorWatchdog.
 	 */
-	@Input() public watchdogConfig?: WatchdogConfig;
+	@Input() public editorWatchdogConfig?: WatchdogConfig;
 
 	/**
 	 * Allows disabling the two-way data binding mechanism. Disabling it can boost performance for large documents.
@@ -391,7 +391,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, OnChanges, C
 			} );
 		} else {
 			// In the other case create the watchdog by hand to keep the editor running.
-			const editorWatchdog: CKEditor5.EditorWatchdog = new EditorWatchdog( this.editor, this.watchdogConfig );
+			const editorWatchdog: CKEditor5.EditorWatchdog = new EditorWatchdog( this.editor, this.editorWatchdogConfig );
 
 			editorWatchdog.setCreator( creator );
 			editorWatchdog.setDestructor( destructor );

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -6,3 +6,10 @@ declare module '@ckeditor/ckeditor5-watchdog/src/editorwatchdog' {
 
 	export default EditorWatchdog;
 }
+
+declare module '@ckeditor/ckeditor5-watchdog/src/watchdog' {
+	const WatchdogConfig: any;
+	type WatchdogConfig = any;
+
+	export default WatchdogConfig;
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added the `editorWatchdogConfig` property that allows defining configuration for the [Watchdog](https://ckeditor.com/docs/ckeditor5/latest/features/watchdog.html) feature. Closes #351.

---

### Additional information

Related docs PR: https://github.com/ckeditor/ckeditor5/pull/13506
