### PR TITLE
Node version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "webpack-cli": "^4.10.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Updated the required version of Node.js to 16.

MAJOR BREAKING CHANGE: Upgraded the minimal versions of Node.js to `16.0.0` due to the end of LTS.
---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
