### PR TITLE
add ckeditor5 as dev dependencies

### DIFF
--- a/src/ckeditor/package.json
+++ b/src/ckeditor/package.json
@@ -22,6 +22,7 @@
     "@ckeditor/ckeditor5-watchdog": "^37.0.0"
   },
   "devDependencies": {
+    "ckeditor5": "^37.0.1",
     "@ckeditor/ckeditor5-core": "^37.0.0",
     "@ckeditor/ckeditor5-engine": "^37.0.0",
     "@ckeditor/ckeditor5-utils": "^37.0.0"


### PR DESCRIPTION
since `@ckeditor/ckeditor5-watchdog` have been added as `dependencies`, `ckeditor5` is needed as `devDependencies.


### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Message. Closes #364.

May fix https://github.com/ckeditor/ckeditor5-angular/issues/356

---

### Additional information

Shouldn't @ckeditor/ckeditor5-watchdog being a `devDependencies` ?