### PR TITLE
Do not run change detection if `error` does not have observers

### DIFF
--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -364,9 +364,13 @@ export class CKEditorComponent<TEditor extends Editor = Editor> implements After
 		};
 
 		const emitError = () => {
-			this.ngZone.run( () => {
-				this.error.emit();
-			} );
+			// Do not run change detection by re-entering the Angular zone if the `error`
+			// emitter doesn't have any subscribers.
+			// Subscribers are pushed onto the list whenever `error` is listened inside the template:
+			// `<ckeditor (error)="onError(...)"></ckeditor>`.
+			if ( hasObservers( this.error ) ) {
+				this.ngZone.run( () => this.error.emit() );
+			}
 		};
 
 		const element = document.createElement( this.tagName );
@@ -403,7 +407,11 @@ export class CKEditorComponent<TEditor extends Editor = Editor> implements After
 
 			this.editorWatchdog = editorWatchdog;
 
-			this.editorWatchdog.create( element, config );
+			this.ngZone.runOutsideAngular( () => {
+				// Note: must be called outside of the Angular zone too because `create` is calling
+				// `_startErrorHandling` within a microtask which sets up `error` listener on the window.
+				editorWatchdog.create( element, config );
+			} );
 		}
 	}
 
@@ -464,4 +472,10 @@ export class CKEditorComponent<TEditor extends Editor = Editor> implements After
 			} );
 		} );
 	}
+}
+
+function hasObservers<T>( emitter: EventEmitter<T> ): boolean {
+	// Cast to `any` because `observed` property is available in RxJS >= 7.2.0.
+	// Fallback to checking `observers` list if this property is not defined.
+	return ( emitter as any ).observed ?? emitter.observers.length > 0;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Do not run change detection if `error` does not have observers.

The `ngZone.run` is used to re-enter the Angular zone and notify that something may have potentially changed to force Angular to run change detection. The change detection is considered as no-op change detection; basically `tick()` has run but nothing has changed. There's no reason to trigger `ngZone.run` when developers are not listening to the `error` event in their code.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
