### PR TITLE
Added `getId()` method that returns the component id

### DIFF
--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -204,6 +204,10 @@ describe( 'CKEditorComponent', () => {
 
 				expect( component.editorInstance!.data.get() ).toEqual( updatedText );
 			} );
+
+			fit( 'should return component id', async () => {
+				expect( component.getId() ).toMatch( /e[0-9a-z]{32}/ );
+			} );
 		} );
 
 		describe( 'emitters', () => {

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -205,7 +205,7 @@ describe( 'CKEditorComponent', () => {
 				expect( component.editorInstance!.data.get() ).toEqual( updatedText );
 			} );
 
-			fit( 'should return component id', async () => {
+			it( 'should return component id', async () => {
 				expect( component.getId() ).toMatch( /e[0-9a-z]{32}/ );
 			} );
 		} );

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -233,6 +233,10 @@ export class CKEditorComponent<TEditor extends Editor = Editor> implements After
 
 	private id = uid();
 
+	public getId(): string {
+		return this.id;
+	}
+
 	public constructor( elementRef: ElementRef, ngZone: NgZone ) {
 		this.ngZone = ngZone;
 		this.elementRef = elementRef;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added the `getId()` method that returns the component id. Closes #367.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
