### PR TITLE
Do not run change detection if `ready` does not have listeners

### DIFF
--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -340,7 +340,7 @@ export class CKEditorComponent<TEditor extends Editor = Editor> implements After
 	 * because of the issue in the collaboration mode (#6).
 	 */
 	private attachToWatchdog() {
-		// TODO: elementOrData parameter type can be simplified to HTMLElemen after templated Watchdog will be released.
+		// TODO: elementOrData parameter type can be simplified to HTMLElement after templated Watchdog will be released.
 		const creator = ( ( elementOrData: HTMLElement | string | Record<string, string>, config: EditorConfig ) => {
 			return this.ngZone.runOutsideAngular( async () => {
 				this.elementRef.nativeElement.appendChild( elementOrData as HTMLElement );
@@ -351,9 +351,10 @@ export class CKEditorComponent<TEditor extends Editor = Editor> implements After
 					editor.enableReadOnlyMode( ANGULAR_INTEGRATION_READ_ONLY_LOCK_ID );
 				}
 
-				this.ngZone.run( () => {
-					this.ready.emit( editor );
-				} );
+				// Do not run change detection if there're no `ready` listeners outside of the component.
+				if ( hasObservers( this.ready ) ) {
+					this.ngZone.run( () => this.ready.emit( editor ) );
+				}
 
 				this.setUpEditorEvents( editor );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Do not run change detection if `ready` does not have listeners.

The `ngZone.run` is used to re-enter the Angular zone and notify that something may have potentially changed to force Angular to run change detection. The change detection is considered as no-op change detection; basically `tick()` has run but nothing has changed. There's no reason to trigger `ngZone.run` when developers are not listening to the `ready` event in their code.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
