### PR TITLE
Node version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "semver": "^7"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "author": "CKSource (http://cksource.com/)",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
Other: Updated the required version of Node.js to 18 when developing the repository. See ckeditor/ckeditor5#14924.