### PR TITLE
Support for prereleases released via CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,17 +177,17 @@ Make sure to test the package with the production setup (`ng build --configurati
 
 ## Releasing package
 
-### Prerequisites
-
-The release process is automated via CircleCI and it can release both channels: stable (`X.Y.Z`) and pre-releases (`X.Y.Z-alpha.X`, etc.).
+CircleCI automates the release process and can release both channels: stable (`X.Y.Z`) and pre-releases (`X.Y.Z-alpha.X`, etc.).
 
 Before you start, you need to prepare the changelog entries.
 
 1. Make sure the `#master` branch is up-to-date: `git fetch && git checkout master && git pull`.
-1. Prepare a release branch: `git checkout -b release-[YYYY-MM-DD]` where `YYYY-MM-DD` is the current day.
-1. Generate the changelog entries: `yarn run changelog --branch release-[YYYY-MM-DD] [--from [GIT_TAG]]`.
+1. Prepare a release branch: `git checkout -b release-[YYYYMMDD]` where `YYYYMMDD` is the current day.
+1. Generate the changelog entries: `yarn run changelog --branch release-[YYYYMMDD] [--from [GIT_TAG]]`.
 	* By default, the changelog generator uses the latest published tag as a starting point for collecting commits to process.
+
 	  The `--from` modifier option allows overriding the default behavior. It is required when preparing the changelog entries for the next stable release while the previous one was marked as a prerelease, e.g., `@alpha`.
+
 	  **Example**: Let's assume that the `v40.5.0-alpha.0` tag is our latest and that we want to release it on a stable channel. The `--from` modifier should be equal to `--from v40.4.0`.
 	* This task checks what changed in each package and bumps the version accordingly. It won't create a new changelog entry if nothing changes at all. If changes were irrelevant (e.g., only dependencies), it would make an "_internal changes_" entry.
 	* Scan the logs printed by the tool to search for errors (incorrect changelog entries). Incorrect entries (e.g., ones without the type) should be addressed. You may need to create entries for them manually. This is done directly in CHANGELOG.md (in the root directory). Make sure to verify the proposed version after you modify the changelog.

--- a/README.md
+++ b/README.md
@@ -131,50 +131,6 @@ npm run coverage
 
 Play with the application and make sure the component works properly.
 
-### Releasing
-
-This package's release process is automated via CircleCI. Before you start a new release, you'll need to test the package and then prepare the changelog entries.
-
-#### Testing the package before releasing
-
-To test the package used as an npm dependency, first you need to build it.
-
-This project uses [ng-packagr](https://www.npmjs.com/package/ng-packagr) to create the package meeting the Angular Package Format specification.
-
-Calling:
-
-```bash
-npm run build-package
-```
-
-creates a package in the `./dist` directory.
-
-Next, to verify the generated `ckeditor5-angular` package, bootstrap an empty Angular package using [`ng new`](https://angular.io/cli/new) and add the `<ckeditor>` component by following the [guide](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/angular.html).
-
-Then, create a symlink to the `ckeditor5-angular/dist` package directory to test the `ckeditor5-angular` component via this repository.
-
-```bash
-ln -s path/to/ckeditor5-angular/dist node_modules/\@ckeditor/ckeditor5-angular
-```
-
-Make sure that the `preserveSymlinks` option is set to `true` for the `build` architect in `angular.json`:
-
-```json
-{
-	"project-name": {
-		"architect": {
-			"build": {
-				"options": {
-					"preserveSymlinks": true
-				}
-			}
-		}
-	}
-}
-```
-
-Make sure to test the package with the production setup (`ng build --configuration production`) and with older Angular versions (at least with the 9.1).
-
 ## Releasing package
 
 CircleCI automates the release process and can release both channels: stable (`X.Y.Z`) and pre-releases (`X.Y.Z-alpha.X`, etc.).

--- a/README.md
+++ b/README.md
@@ -175,18 +175,24 @@ Make sure that the `preserveSymlinks` option is set to `true` for the `build` ar
 
 Make sure to test the package with the production setup (`ng build --configuration production`) and with older Angular versions (at least with the 9.1).
 
-#### Generating the changelog
+## Releasing package
+
+### Prerequisites
+
+The release process is automated via CircleCI and it can release both channels: stable (`X.Y.Z`) and pre-releases (`X.Y.Z-alpha.X`, etc.).
+
+Before you start, you need to prepare the changelog entries.
 
 1. Make sure the `#master` branch is up-to-date: `git fetch && git checkout master && git pull`.
 1. Prepare a release branch: `git checkout -b release-[YYYY-MM-DD]` where `YYYY-MM-DD` is the current day.
-1. Generate the changelog entries: `yarn run changelog --branch release-[YYYY-MM-DD]`.
-    * This task checks what changed in each package and bumps the version accordingly. If nothing changes at all, it won't create a new changelog entry. If changes were irrelevant (e.g., only dependencies), it would make an "internal changes" entry.
-    * Scan the logs printed by the tool to search for errors (incorrect changelog entries). Incorrect entries (e.g., ones without the type) should be addressed. You may need to create entries for them manually. This is done directly in CHANGELOG.md (in the root directory). Make sure to verify the proposed version after you modify the changelog.
+1. Generate the changelog entries: `yarn run changelog --branch release-[YYYY-MM-DD] [--from [GIT_TAG]]`.
+	* By default, the changelog generator uses the latest published tag as a starting point for collecting commits to process.
+	  The `--from` modifier option allows overriding the default behavior. It is required when preparing the changelog entries for the next stable release while the previous one was marked as a prerelease, e.g., `@alpha`.
+	  **Example**: Let's assume that the `v40.5.0-alpha.0` tag is our latest and that we want to release it on a stable channel. The `--from` modifier should be equal to `--from v40.4.0`.
+	* This task checks what changed in each package and bumps the version accordingly. It won't create a new changelog entry if nothing changes at all. If changes were irrelevant (e.g., only dependencies), it would make an "_internal changes_" entry.
+	* Scan the logs printed by the tool to search for errors (incorrect changelog entries). Incorrect entries (e.g., ones without the type) should be addressed. You may need to create entries for them manually. This is done directly in CHANGELOG.md (in the root directory). Make sure to verify the proposed version after you modify the changelog.
 1. Commit all changes and prepare a new pull request targeting the `#master` branch.
-
-#### Release the package
-
-Once the package is successfully tested and the pull request with changelog is ready, ping the @ckeditor/ckeditor-5-devops team to review the pull request and trigger the release process.
+1. Ping the `@ckeditor/ckeditor-5-devops` team to review the pull request and trigger the release process.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -184,13 +184,13 @@ Before you start, you need to prepare the changelog entries.
 1. Make sure the `#master` branch is up-to-date: `git fetch && git checkout master && git pull`.
 1. Prepare a release branch: `git checkout -b release-[YYYYMMDD]` where `YYYYMMDD` is the current day.
 1. Generate the changelog entries: `yarn run changelog --branch release-[YYYYMMDD] [--from [GIT_TAG]]`.
-	* By default, the changelog generator uses the latest published tag as a starting point for collecting commits to process.
+    * By default, the changelog generator uses the latest published tag as a starting point for collecting commits to process.
 
-	  The `--from` modifier option allows overriding the default behavior. It is required when preparing the changelog entries for the next stable release while the previous one was marked as a prerelease, e.g., `@alpha`.
+      The `--from` modifier option allows overriding the default behavior. It is required when preparing the changelog entries for the next stable release while the previous one was marked as a prerelease, e.g., `@alpha`.
 
-	  **Example**: Let's assume that the `v40.5.0-alpha.0` tag is our latest and that we want to release it on a stable channel. The `--from` modifier should be equal to `--from v40.4.0`.
-	* This task checks what changed in each package and bumps the version accordingly. It won't create a new changelog entry if nothing changes at all. If changes were irrelevant (e.g., only dependencies), it would make an "_internal changes_" entry.
-	* Scan the logs printed by the tool to search for errors (incorrect changelog entries). Incorrect entries (e.g., ones without the type) should be addressed. You may need to create entries for them manually. This is done directly in CHANGELOG.md (in the root directory). Make sure to verify the proposed version after you modify the changelog.
+      **Example**: Let's assume that the `v40.5.0-alpha.0` tag is our latest and that we want to release it on a stable channel. The `--from` modifier should be equal to `--from v40.4.0`.
+    * This task checks what changed in each package and bumps the version accordingly. It won't create a new changelog entry if nothing changes at all. If changes were irrelevant (e.g., only dependencies), it would make an "_internal changes_" entry.
+    * Scan the logs printed by the tool to search for errors (incorrect changelog entries). Incorrect entries (e.g., ones without the type) should be addressed. You may need to create entries for them manually. This is done directly in CHANGELOG.md (in the root directory). Make sure to verify the proposed version after you modify the changelog.
 1. Commit all changes and prepare a new pull request targeting the `#master` branch.
 1. Ping the `@ckeditor/ckeditor-5-devops` team to review the pull request and trigger the release process.
 

--- a/scripts/ci/is-project-ready-to-release.js
+++ b/scripts/ci/is-project-ready-to-release.js
@@ -9,36 +9,18 @@
 
 'use strict';
 
-const { execSync } = require( 'child_process' );
 const releaseTools = require( '@ckeditor/ckeditor5-dev-release-tools' );
-const semver = require( 'semver' );
-const { name } = require( '../../package.json' );
+const { name: packageName } = require( '../../package.json' );
 
-const latestPublishedVersion = execSync( `npm view ${ name }@latest version`, { encoding: 'utf-8' } ).trim();
 const changelogVersion = releaseTools.getLastFromChangelog();
+const npmTag = releaseTools.getNpmTagFromVersion( changelogVersion );
 
-if ( getVersionTag( changelogVersion ) !== 'latest' ) {
-	console.log( `Aborting due non-latest changelog version (${ changelogVersion }).` );
-	process.exit( 1 );
-}
-
-if ( semver.lte( changelogVersion, latestPublishedVersion ) ) {
-	console.log(
-		`The proposed changelog (${ changelogVersion }) version is not greater than the published one (${ latestPublishedVersion }).`
-	);
-	process.exit( 1 );
-}
-
-console.log( 'The project is ready to release.' );
-
-/**
- * Returns an npm tag based on the specified release version.
- *
- * @param {String} version
- * @returns {String}
- */
-function getVersionTag( version ) {
-	const [ versionTag ] = semver.prerelease( version ) || [ 'latest' ];
-
-	return versionTag;
-}
+releaseTools.isVersionPublishableForTag( packageName, changelogVersion, npmTag )
+	.then( result => {
+		if ( !result ) {
+			console.error( `The proposed changelog (${ changelogVersion }) version is not higher than the already published one.` );
+			process.exit( 1 );
+		} else {
+			console.log( 'The project is ready to release.' );
+		}
+	} );

--- a/scripts/publishpackages.js
+++ b/scripts/publishpackages.js
@@ -21,6 +21,10 @@ const versionChangelog = releaseTools.getChangesForVersion( latestVersion );
 
 let githubToken;
 
+if ( !cliArguments.npmTag ) {
+	cliArguments.npmTag = releaseTools.getNpmTagFromVersion( latestVersion );
+}
+
 const tasks = new Listr( [
 	{
 		title: 'Publishing packages.',

--- a/scripts/utils/parsearguments.js
+++ b/scripts/utils/parsearguments.js
@@ -30,7 +30,7 @@ module.exports = function parseArguments( cliArguments ) {
 			branch: 'master',
 			ci: false,
 			'compile-only': false,
-			'npm-tag': 'latest',
+			'npm-tag': null,
 			verbose: false
 		}
 	};
@@ -55,7 +55,7 @@ module.exports = function parseArguments( cliArguments ) {
  *
  * @property {String} [branch='master']
  *
- * @property {String} [npmTag='latest']
+ * @property {String|null} [npmTag=null]
  *
  * @property {Boolean} [compileOnly=false]
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,12 +1328,12 @@
     node-fetch "^2.6.7"
     slack-notify "^2.0.6"
 
-"@ckeditor/ckeditor5-dev-release-tools@^40.2.0":
-  version "40.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-dev-release-tools/-/ckeditor5-dev-release-tools-40.3.0.tgz#4abe75b71c79461cf1a7e588d7d40b375407da7e"
-  integrity sha512-Pm4al2J5z2kuGC4i7oVkIr+Knhk3Ikl8OcYFfSPxvrFSHLaeNPzcxemQjES0f6EuDrybQx+1GyCO5qet8UOolQ==
+"@ckeditor/ckeditor5-dev-release-tools@^40.5.0":
+  version "40.5.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-dev-release-tools/-/ckeditor5-dev-release-tools-40.5.0.tgz#90283574bf9da14bd7a8944656450b967fa7e375"
+  integrity sha512-FsZxwBqUrZFxO2jbZ0E0wHxJln0jebLC5YQgG9Q5haylTqooCQDQiiPheMoLAlCur2ZqbHYrWhqj0mV2Z7jZ2w==
   dependencies:
-    "@ckeditor/ckeditor5-dev-utils" "^40.3.0"
+    "@ckeditor/ckeditor5-dev-utils" "^40.5.0"
     "@octokit/rest" "^19.0.0"
     chalk "^4.0.0"
     cli-columns "^4.0.0"
@@ -1368,12 +1368,52 @@
     rimraf "^3.0.2"
     webpack-sources "^2.0.1"
 
-"@ckeditor/ckeditor5-dev-utils@^40.2.0", "@ckeditor/ckeditor5-dev-utils@^40.3.0":
+"@ckeditor/ckeditor5-dev-translations@^40.5.0":
+  version "40.5.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-dev-translations/-/ckeditor5-dev-translations-40.5.0.tgz#aea775f0a61df749c4ecc4033f9dfb4a6ae54265"
+  integrity sha512-oYTpZAchobqYjeWX5v2Awhg8HRZ6UKiFNc7CeSvfm4l3krJPO4NAxfNZrdRwT4pCn4mz9zovfUvJlb2oWVEQxQ==
+  dependencies:
+    "@babel/parser" "^7.18.9"
+    "@babel/traverse" "^7.18.9"
+    chalk "^4.0.0"
+    pofile "^1.0.9"
+    rimraf "^3.0.2"
+    webpack-sources "^2.0.1"
+
+"@ckeditor/ckeditor5-dev-utils@^40.2.0":
   version "40.3.0"
   resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-dev-utils/-/ckeditor5-dev-utils-40.3.0.tgz#1ae4eef9f02570a4536c53436a6f8ac991fcb842"
   integrity sha512-+Mk4URN9whDJAoSSbYvWXVAPDwoPTPtALCQHZkW2vt5fYt6gGf+0pFuxy/J+yXjW+CWnxE2WDsmm6gX1hSTkug==
   dependencies:
     "@ckeditor/ckeditor5-dev-translations" "^40.3.0"
+    chalk "^3.0.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.6.1"
+    css-loader "^5.2.7"
+    cssnano "^6.0.3"
+    del "^5.0.0"
+    esbuild-loader "~3.0.1"
+    fs-extra "^9.1.0"
+    is-interactive "^1.0.0"
+    javascript-stringify "^1.6.0"
+    mini-css-extract-plugin "^2.4.2"
+    postcss "^8.4.12"
+    postcss-import "^14.1.0"
+    postcss-loader "^4.3.0"
+    postcss-mixins "^9.0.2"
+    postcss-nesting "^10.1.4"
+    raw-loader "^4.0.1"
+    shelljs "^0.8.1"
+    style-loader "^2.0.0"
+    terser-webpack-plugin "^4.2.3"
+    through2 "^3.0.1"
+
+"@ckeditor/ckeditor5-dev-utils@^40.5.0":
+  version "40.5.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-dev-utils/-/ckeditor5-dev-utils-40.5.0.tgz#5daa01c3053283ff9fad037c05a620ae069bca48"
+  integrity sha512-O8Fb7M9BIwI59xIK0/cnVG3u5OK2k2US3Q8rphnwfxWItmOPAnnt8zZt5Kpsa3Rbpe/kIIi5BOgOOjZO8dFHdw==
+  dependencies:
+    "@ckeditor/ckeditor5-dev-translations" "^40.5.0"
     chalk "^3.0.0"
     cli-cursor "^3.1.0"
     cli-spinners "^2.6.1"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Support for releasing the repository for prereleases.

---

### Additional information

Part of https://github.com/cksource/ckeditor5-internal/issues/3710.
