### PR TITLE
Add missing `@ckeditor/ckeditor5-integrations-common` dependency

### DIFF
--- a/src/ckeditor/ng-package.json
+++ b/src/ckeditor/ng-package.json
@@ -2,5 +2,6 @@
   "lib": {
     "entryFile": "./index.ts"
   },
-  "dest": "../../dist"
+  "dest": "../../dist",
+  "allowedNonPeerDependencies": ["@ckeditor/ckeditor5-integrations-common"]
 }

--- a/src/ckeditor/package.json
+++ b/src/ckeditor/package.json
@@ -18,6 +18,9 @@
     "ckeditor5",
     "ckeditor 5"
   ],
+  "dependencies": {
+    "@ckeditor/ckeditor5-integrations-common": "^2.0.0"
+  },
   "peerDependencies": {
     "@angular/core": ">=16.0.0",
     "@angular/common": ">=16.0.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Add missing `@ckeditor/ckeditor5-integrations-common` dependency to `package.json`.
