### PR TITLE
Print editor errors in console if there is no `(error)` observer.

### DIFF
--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -390,6 +390,9 @@ export class CKEditorComponent<TEditor extends Editor = Editor> implements After
 			// `<ckeditor (error)="onError(...)"></ckeditor>`.
 			if ( hasObservers( this.error ) ) {
 				this.ngZone.run( () => this.error.emit( e ) );
+			} else {
+				// Print error to the console when there are no subscribers to the `error` event.
+				console.error( e );
 			}
 		};
 		const element = document.createElement( this.tagName );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Print editor errors in console if there is no `(error)` observer.

---

### Additional information

Closes https://github.com/cksource/ckeditor5-commercial/issues/6775
