### PR TITLE
Bump integrations common to `2.2.1`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/platform-browser": "^16",
     "@angular/platform-browser-dynamic": "^16",
     "@angular/router": "^16",
-    "@ckeditor/ckeditor5-integrations-common": "^2.2.0",
+    "@ckeditor/ckeditor5-integrations-common": "^2.2.1",
     "core-js": "^3.21.1",
     "rxjs": "^6.5.5",
     "tslib": "^2.0.3",

--- a/src/ckeditor/package.json
+++ b/src/ckeditor/package.json
@@ -19,7 +19,7 @@
     "ckeditor 5"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-integrations-common": "^2.0.0"
+    "@ckeditor/ckeditor5-integrations-common": "^2.2.1"
   },
   "peerDependencies": {
     "@angular/core": ">=16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,10 +2258,10 @@
     "@ckeditor/ckeditor5-utils" "43.3.1"
     ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-integrations-common@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-integrations-common/-/ckeditor5-integrations-common-2.2.0.tgz#3eb75e21eddc880c87a675125ec3fcfe0c258847"
-  integrity sha512-qH68tqgyMibuejo+VAJ+iSH3ZmZweqBEzaawv9hZb4zzSMkBityWBjSc2hKXMtmJgCNsbSK84cyHpa5J/MNyLg==
+"@ckeditor/ckeditor5-integrations-common@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-integrations-common/-/ckeditor5-integrations-common-2.2.1.tgz#a83e57011c3b3a8191cc284e570544cc87a3578e"
+  integrity sha512-FcB6Lz3njoxvBPkSAUyhKi5qrfPZ3FBVT4d9ncOaU5GVxwYR+e+Wo360fjKt0v0XeKNyTz7j1xJONbyackMTzg==
 
 "@ckeditor/ckeditor5-language@43.3.1":
   version "43.3.1"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Bump integrations common to `2.2.1` to align minor license check fixes. 
