### PR TITLE
Added `dryRun` parameter to `commitAndTag()` function to run commit validations during a release

### DIFF
--- a/scripts/preparepackages.mjs
+++ b/scripts/preparepackages.mjs
@@ -132,19 +132,12 @@ const tasks = new Listr( [
 		task: () => {
 			return releaseTools.commitAndTag( {
 				version: latestVersion,
+				dryRun: cliArguments.compileOnly,
 				files: [
 					'package.json',
 					'src/ckeditor/plugins/angular-integration-usage-data.plugin.ts'
 				]
 			} );
-		},
-		skip: () => {
-			// When compiling the packages only, do not update any values.
-			if ( cliArguments.compileOnly ) {
-				return true;
-			}
-
-			return false;
 		}
 	}
 ], getListrOptions( cliArguments ) );


### PR DESCRIPTION
…alidatinos during a release.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added `dryRun` parameter to `commitAndTag()` function to run commit validations during a release. See ckeditor/ckeditor5#17967.

---

### Additional information

⚠️ Depends on https://github.com/ckeditor/ckeditor5-dev/pull/1077.
