### PR TITLE
Accept internal CKEditor 5 releases in `peerDependencies`.

### DIFF
--- a/.changelog/20260116152356_angular_530_accept_internal_ckeditor5_releases.md
+++ b/.changelog/20260116152356_angular_530_accept_internal_ckeditor5_releases.md
@@ -1,0 +1,6 @@
+---
+type: Other
+closes: https://github.com/ckeditor/ckeditor5-angular/issues/530
+---
+
+Accept internal CKEditor 5 releases in `peerDependencies`.

--- a/src/ckeditor/package.json
+++ b/src/ckeditor/package.json
@@ -25,7 +25,7 @@
     "@angular/core": ">=19.2.15",
     "@angular/common": ">=19.2.15",
     "@angular/forms": ">=19.2.15",
-    "ckeditor5": ">=47.0.0 || ^0.0.0-nightly",
+    "ckeditor5": ">=47.0.0 || ^0.0.0-nightly || ^0.0.0-internal",
     "rxjs": ">=6.0.0"
   },
   "author": "CKSource (http://cksource.com/)",


### PR DESCRIPTION
### 🚀 Summary

Accept internal CKEditor 5 releases in `peerDependencies`.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-angular/issues/530

---

### 💡 Additional information

N/A
