### PR TITLE
Add support for CKEditor 48.x data config format

### DIFF
--- a/.changelog/20260317134002_ck_547.md
+++ b/.changelog/20260317134002_ck_547.md
@@ -1,0 +1,7 @@
+---
+type: Feature
+closes:
+  - https://github.com/ckeditor/ckeditor5-angular/issues/547
+---
+
+Added support for CKEditor 5 `48.0.0` and the new `roots` editor configuration.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser": "^19.2.19",
     "@angular/platform-browser-dynamic": "^19.2.19",
     "@angular/router": "^19.2.19",
-    "@ckeditor/ckeditor5-integrations-common": "^2.2.2",
+    "@ckeditor/ckeditor5-integrations-common": "^2.2.4",
     "core-js": "^3.21.1",
     "rxjs": "^6.5.5",
     "tslib": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  ajv@^8: ^8.18.0
   diff@^7: ^8.0.3
   diff@^8: ^8.0.3
   qs@<6.14.1: ^6.14.2
-  tar@^6: ^7.5.4
-  ajv@^8: ^8.18.0
   rollup@^4: ^4.59.0
+  tar@^6: ^7.5.4
   webpack@^5: ^5.104.1
 
 importers:
@@ -19,34 +19,34 @@ importers:
     dependencies:
       '@angular/animations':
         specifier: ^19.2.19
-        version: 19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))
+        version: 19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))
       '@angular/common':
         specifier: ^19.2.19
-        version: 19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
+        version: 19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
       '@angular/compiler':
         specifier: ^19.2.19
-        version: 19.2.19
+        version: 19.2.20
       '@angular/core':
         specifier: ^19.2.19
-        version: 19.2.19(rxjs@6.6.7)(zone.js@0.15.1)
+        version: 19.2.20(rxjs@6.6.7)(zone.js@0.15.1)
       '@angular/forms':
         specifier: ^19.2.19
-        version: 19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(rxjs@6.6.7)
+        version: 19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(rxjs@6.6.7)
       '@angular/platform-browser':
         specifier: ^19.2.19
-        version: 19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))
+        version: 19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))
       '@angular/platform-browser-dynamic':
         specifier: ^19.2.19
-        version: 19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/compiler@19.2.19)(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))
+        version: 19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/compiler@19.2.20)(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))
       '@angular/router':
         specifier: ^19.2.19
-        version: 19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(rxjs@6.6.7)
+        version: 19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(rxjs@6.6.7)
       '@ckeditor/ckeditor5-integrations-common':
-        specifier: ^2.2.2
-        version: 2.2.3(ckeditor5@47.6.0)
+        specifier: ^2.2.4
+        version: 2.2.4(ckeditor5@47.6.1)
       core-js:
         specifier: ^3.21.1
-        version: 3.46.0
+        version: 3.48.0
       rxjs:
         specifier: ^6.5.5
         version: 6.6.7
@@ -59,73 +59,73 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: ^2.2.3
-        version: 2.2.3(@angular-devkit/build-angular@19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1))(@angular/build@19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.6)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1))
+        version: 2.3.1(@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2))(@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.8)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2))
       '@analogjs/vitest-angular':
         specifier: ^2.2.3
-        version: 2.2.3(ea499e6060c9e668453fb89aea7ad742)
+        version: 2.3.1(d014764e7ce56e7bffbd51c6d32db63d)
       '@angular-devkit/build-angular':
         specifier: ^19.2.19
-        version: 19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1)
+        version: 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2)
       '@angular/cli':
         specifier: ^19.2.20
-        version: 19.2.20(@types/node@14.18.63)(chokidar@4.0.3)
+        version: 19.2.22(@types/node@14.18.63)(chokidar@4.0.3)
       '@angular/compiler-cli':
         specifier: ^19.2.19
-        version: 19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4)
+        version: 19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4)
       '@angular/language-service':
         specifier: ^19.2.19
-        version: 19.2.19
+        version: 19.2.20
       '@ckeditor/ckeditor5-dev-bump-year':
         specifier: ^54.3.4
-        version: 54.3.4
+        version: 54.5.0
       '@ckeditor/ckeditor5-dev-changelog':
         specifier: ^54.3.4
-        version: 54.3.4(@babel/core@7.28.4)(@types/node@14.18.63)(typescript@5.5.4)(webpack@5.105.2)
+        version: 54.5.0(@babel/core@7.26.10)(@types/node@14.18.63)(typescript@5.5.4)(webpack@5.105.4)
       '@ckeditor/ckeditor5-dev-ci':
         specifier: ^54.3.4
-        version: 54.3.4
+        version: 54.5.0
       '@ckeditor/ckeditor5-dev-release-tools':
         specifier: ^54.3.4
-        version: 54.3.4(@babel/core@7.28.4)(@types/node@14.18.63)(typescript@5.5.4)(webpack@5.105.2)
+        version: 54.5.0(@babel/core@7.26.10)(@types/node@14.18.63)(typescript@5.5.4)(webpack@5.105.4)
       '@ckeditor/ckeditor5-dev-utils':
         specifier: ^54.3.4
-        version: 54.3.4(@babel/core@7.28.4)(typescript@5.5.4)(webpack@5.105.2)
+        version: 54.5.0(@babel/core@7.26.10)(typescript@5.5.4)(webpack@5.105.4)
       '@types/node':
         specifier: ^14.11.8
         version: 14.18.63
       '@vitest/browser-playwright':
         specifier: ^4.0.18
-        version: 4.0.18(playwright@1.58.2)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(vitest@4.0.18)
+        version: 4.1.0(playwright@1.58.2)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(vitest@4.1.0)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.1.0(@vitest/browser@4.1.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(vitest@4.1.0))(vitest@4.1.0)
       ckeditor5:
         specifier: ^47.6.0
-        version: 47.6.0
+        version: 47.6.1
       ckeditor5-premium-features:
         specifier: ^47.6.0
-        version: 47.6.0(ckeditor5@47.6.0)
+        version: 47.6.1(ckeditor5@47.6.1)
       css-loader:
         specifier: ^5.2.7
-        version: 5.2.7(webpack@5.105.2)
+        version: 5.2.7(webpack@5.105.4)
       cypress:
         specifier: ^13.17.0
         version: 13.17.0
       eslint:
         specifier: ^9.38.0
-        version: 9.38.0(jiti@2.6.1)
+        version: 9.39.4(jiti@2.6.1)
       eslint-config-ckeditor5:
         specifier: ^13.0.0
-        version: 13.0.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
+        version: 13.0.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
       eslint-plugin-ckeditor5-rules:
         specifier: ^13.0.0
-        version: 13.0.0
+        version: 13.0.1
       fs-extra:
         specifier: ^10.0.1
         version: 10.1.0
       globals:
         specifier: ^16.1.0
-        version: 16.4.0
+        version: 16.5.0
       husky:
         specifier: ^8.0.2
         version: 8.0.3
@@ -137,28 +137,28 @@ importers:
         version: 1.2.8
       ng-packagr:
         specifier: ^19.2.2
-        version: 19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
+        version: 19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
       playwright:
         specifier: ^1.52.0
         version: 1.58.2
       postcss-loader:
         specifier: ^4.3.0
-        version: 4.3.0(postcss@8.5.6)(webpack@5.105.2)
+        version: 4.3.0(postcss@8.5.8)(webpack@5.105.4)
       raw-loader:
         specifier: ^4.0.1
-        version: 4.0.2(webpack@5.105.2)
+        version: 4.0.2(webpack@5.105.4)
       semver:
         specifier: ^7
-        version: 7.7.3
+        version: 7.7.4
       start-server-and-test:
         specifier: ^2.1.5
         version: 2.1.5
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.105.2)
+        version: 2.0.0(webpack@5.105.4)
       ts-loader:
         specifier: ^9.4.3
-        version: 9.5.4(typescript@5.5.4)(webpack@5.105.2)
+        version: 9.5.4(typescript@5.5.4)(webpack@5.105.4)
       ts-node:
         specifier: ^9.0.0
         version: 9.1.1(typescript@5.5.4)
@@ -167,37 +167,37 @@ importers:
         version: 5.5.4
       typescript-eslint:
         specifier: ^8.32.0
-        version: 8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
+        version: 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
       upath:
         specifier: ^2.0.1
         version: 2.0.1
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@14.18.63)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1)
+        version: 4.1.0(@types/node@14.18.63)(@vitest/browser-playwright@4.1.0)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
       webpack:
         specifier: ^5.104.1
-        version: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+        version: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
-        version: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2)
+        version: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
 
   src/ckeditor:
     dependencies:
       '@angular/common':
         specifier: '>=19.2.19'
-        version: 19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
+        version: 19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
       '@angular/core':
         specifier: '>=19.2.19'
-        version: 19.2.19(rxjs@6.6.7)(zone.js@0.15.1)
+        version: 19.2.20(rxjs@6.6.7)(zone.js@0.15.1)
       '@angular/forms':
         specifier: '>=19.2.19'
-        version: 19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(rxjs@6.6.7)
+        version: 19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(rxjs@6.6.7)
       '@ckeditor/ckeditor5-integrations-common':
-        specifier: ^2.2.2
-        version: 2.2.3(ckeditor5@47.2.0)
+        specifier: ^2.2.4
+        version: 2.2.4(ckeditor5@47.6.1)
       ckeditor5:
         specifier: '>=47.0.0 || ^0.0.0-nightly || ^0.0.0-internal'
-        version: 47.2.0
+        version: 47.6.1
       rxjs:
         specifier: '>=6.0.0'
         version: 6.6.7
@@ -208,8 +208,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@analogjs/vite-plugin-angular@2.2.3':
-    resolution: {integrity: sha512-OqVfiJsaHdHMxzvK0heVvp8MenSXh+xib6/p+v3d44kJ3J7ooD4gRx/jKC350zkgRKwcZc3a0ybGUnG6LEF7mg==}
+  '@analogjs/vite-plugin-angular@2.3.1':
+    resolution: {integrity: sha512-6ttSrMFBYwvS5JfovagfhkLaje1RjzztIniBWtH5G8wc6vrud77/sRJWVaVC4Ri4XRBTQ2kG5thSDumccX1B7g==}
     peerDependencies:
       '@angular-devkit/build-angular': ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
       '@angular/build': ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
@@ -219,30 +219,31 @@ packages:
       '@angular/build':
         optional: true
 
-  '@analogjs/vitest-angular@2.2.3':
-    resolution: {integrity: sha512-514A8RqT4sQnWj/3pHnoGrvDLYjcUTWL3d00GCQ4MVRUpisUg2R8tC/PZ/3ZARK5SskIwy5LwPEg4RFX0iOSug==}
+  '@analogjs/vitest-angular@2.3.1':
+    resolution: {integrity: sha512-wbTLgeWDR9qPohE5vzGi4GJ0oHC/GmAhkzEMbt6xoAHbhvMsRrqsiiku03tejHcPqErMlsBotIeR/huAbJferQ==}
     peerDependencies:
       '@analogjs/vite-plugin-angular': '*'
       '@angular-devkit/architect': '>=0.1500.0 < 0.2200.0'
+      '@angular-devkit/schematics': '>=17.0.0'
       vitest: ^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0
+      zone.js: '>=0.14.0'
+    peerDependenciesMeta:
+      zone.js:
+        optional: true
 
-  '@angular-devkit/architect@0.1902.19':
-    resolution: {integrity: sha512-iexYDIYpGAeAU7T60bGcfrGwtq1bxpZixYxWuHYiaD1b5baQgNSfd1isGEOh37GgDNsf4In9i2LOLPm0wBdtgQ==}
+  '@angular-devkit/architect@0.1902.22':
+    resolution: {integrity: sha512-98NCVZZwDoL1oW0aj9Wd7piIkt/oSjMZEI04f3oL5nGD1LoXcN7BrYKXIpZ4NP4Pfn+7gJo3nrhglHnhcwQXyg==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
-  '@angular-devkit/architect@0.1902.20':
-    resolution: {integrity: sha512-tEM8PX9RTIvgEPJH/9nDaGlhbjZf9BBFS2FXKuOwKB+NFvfZuuDpPH7CzJKyyvkQLPtoNh2Y9C92m2f+RXsBmQ==}
-    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
-
-  '@angular-devkit/build-angular@19.2.19':
-    resolution: {integrity: sha512-uIxi6Vzss6+ycljVhkyPUPWa20w8qxJL9lEn0h6+sX/fhM8Djt0FHIuTQjoX58EoMaQ/1jrXaRaGimkbaFcG9A==}
+  '@angular-devkit/build-angular@19.2.22':
+    resolution: {integrity: sha512-FBH8R1IvqFaM3M/Hh/Ixj5yptUND7FTH2zbg/jsvrwM4YpZ2Nu8cpc7iZeSzv4TJKPFDAbSuyBJnzbGF70eOGQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
       '@angular/compiler-cli': ^19.0.0 || ^19.2.0-next.0
       '@angular/localize': ^19.0.0 || ^19.2.0-next.0
       '@angular/platform-server': ^19.0.0 || ^19.2.0-next.0
       '@angular/service-worker': ^19.0.0 || ^19.2.0-next.0
-      '@angular/ssr': ^19.2.19
+      '@angular/ssr': ^19.2.22
       '@web/test-runner': ^0.20.0
       browser-sync: ^3.0.2
       jest: ^29.5.0
@@ -278,15 +279,15 @@ packages:
       tailwindcss:
         optional: true
 
-  '@angular-devkit/build-webpack@0.1902.19':
-    resolution: {integrity: sha512-x2tlGg5CsUveFzuRuqeHknSbGirSAoRynEh+KqPRGK0G3WpMViW/M8SuVurecasegfIrDWtYZ4FnVxKqNbKwXQ==}
+  '@angular-devkit/build-webpack@0.1902.22':
+    resolution: {integrity: sha512-DLiz60fBwHC4ki5q+D+rx8af+uPvtL9Uy9HQ1Lk5Jl+eTJeuKp2t6PwxwzAN5GiFSF8oU1YE7EWYCCuO4/LvxQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
       webpack: ^5.104.1
       webpack-dev-server: ^5.0.2
 
-  '@angular-devkit/core@19.2.19':
-    resolution: {integrity: sha512-JbLL+4IMLMBgjLZlnPG4lYDfz4zGrJ/s6Aoon321NJKuw1Kb1k5KpFu9dUY0BqLIe8xPQ2UJBpI+xXdK5MXMHQ==}
+  '@angular-devkit/core@19.2.22':
+    resolution: {integrity: sha512-OqN/Ded+ZKypPZN5+qUFwtnKGl7FKpxJXYO2Vts5vLBojY5goCZd9SGW1CyXeuPnisRUW+vjqBQbWYuEUh36Tw==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
       chokidar: ^4.0.0
@@ -294,28 +295,19 @@ packages:
       chokidar:
         optional: true
 
-  '@angular-devkit/core@19.2.20':
-    resolution: {integrity: sha512-4AAmHlv+H1/2Nmsp6QsX8YQxjC/v5QAzc+76He7K/x3iIuLCntQE2BYxonSZMiQ3M8gc/yxTfyZoPYjSDDvWMA==}
-    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
-    peerDependencies:
-      chokidar: ^4.0.0
-    peerDependenciesMeta:
-      chokidar:
-        optional: true
-
-  '@angular-devkit/schematics@19.2.20':
-    resolution: {integrity: sha512-o2eexF1fLZU93V3utiQLNgyNaGvFhDqpITNQcI1qzv2ZkvFHg9WZjFtZKtm805JAE/DND8oAJ1p+BoxU++Qg8g==}
+  '@angular-devkit/schematics@19.2.22':
+    resolution: {integrity: sha512-tvfu5jhem1o8qidVxvXe5KfCij65ioMLCOFA947DD+zb3yTl5pJyDm2dqzbOehuQw0fmH4XPQukRJsCUy+UwaA==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
-  '@angular/animations@19.2.19':
-    resolution: {integrity: sha512-XGChk+26XZpcwzIQUVjgLxGVC//m5TaDrogseQNIGs2Chzv6KYbo91HftL69fTiM5udRYjg6IV7XEzDNF/GVUw==}
+  '@angular/animations@19.2.20':
+    resolution: {integrity: sha512-TQ4OCazTRAge45FIp3bzO/chImObmasPzprgEzKSDckjGbshAWlYXeCe3U8YaGNaWnkzByyIRNV4P4aHe63M0w==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     peerDependencies:
-      '@angular/common': 19.2.19
-      '@angular/core': 19.2.19
+      '@angular/common': 19.2.20
+      '@angular/core': 19.2.20
 
-  '@angular/build@19.2.19':
-    resolution: {integrity: sha512-SFzQ1bRkNFiOVu+aaz+9INmts7tDUrsHLEr9HmARXr9qk5UmR8prlw39p2u+Bvi6/lCiJ18TZMQQl9mGyr63lg==}
+  '@angular/build@19.2.22':
+    resolution: {integrity: sha512-7TA2YyMpkFiAoiEP5v8IQVtFEAiphZz1B6NmfvgWRlvnpktSe67qXMDC/IoWnjtV7jyVufQg2BV1prrWIwfwKw==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
       '@angular/compiler': ^19.0.0 || ^19.2.0-next.0
@@ -323,7 +315,7 @@ packages:
       '@angular/localize': ^19.0.0 || ^19.2.0-next.0
       '@angular/platform-server': ^19.0.0 || ^19.2.0-next.0
       '@angular/service-worker': ^19.0.0 || ^19.2.0-next.0
-      '@angular/ssr': ^19.2.19
+      '@angular/ssr': ^19.2.22
       karma: ^6.4.0
       less: ^4.2.0
       ng-packagr: ^19.0.0 || ^19.2.0-next.0
@@ -350,77 +342,77 @@ packages:
       tailwindcss:
         optional: true
 
-  '@angular/cli@19.2.20':
-    resolution: {integrity: sha512-3vw49xDGqOi63FES/6D+Lw0Sl42FSZKowUxBMY0CnXD8L93Qwvcf4ASFmUoNJRSTOJuuife1+55vY62cpOWBdg==}
+  '@angular/cli@19.2.22':
+    resolution: {integrity: sha512-lyqlNfRf3PnmSSPbLKLqzol3jWoJXyTYO8u6PA8tMPjQczzWNisrwCjso7vJnECa/R19mFVlVjVNfg0lxsqfFg==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     hasBin: true
 
-  '@angular/common@19.2.19':
-    resolution: {integrity: sha512-/JYo8jJZ6BAgw3IVYJpinAfGb+RbaZubrElFvaq450BWxDPInv7Z99HKEQ3qEBRsBeIAQ/WrKXDxoJSjy7QMNQ==}
+  '@angular/common@19.2.20':
+    resolution: {integrity: sha512-1M3W3FjUUbVKXDMs+yQpBhnkD/pCe0Jn79rPE5W+EGWWxFoLSyGX+fhnRO5m4c9k66p3nvYrikWQ0ZzMv3M5tw==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     peerDependencies:
-      '@angular/core': 19.2.19
+      '@angular/core': 19.2.20
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/compiler-cli@19.2.19':
-    resolution: {integrity: sha512-vdMJX9E7wePN41T+6BYRQBA+XiR9a5DBhs20dqtv8YVireQktH6mxLZIg1pVxkL/gnao2gpl/lOvp0xmC7UN/Q==}
+  '@angular/compiler-cli@19.2.20':
+    resolution: {integrity: sha512-tYYQk8AUz2sEkVl0a3uebduDUXPuKiGEKl2Jryrbn0xh9i1EsxoCjt1VvHnGnksGp3mz4DQihFVEnte0KeVQ5g==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@angular/compiler': 19.2.19
+      '@angular/compiler': 19.2.20
       typescript: '>=5.5 <5.9'
 
-  '@angular/compiler@19.2.19':
-    resolution: {integrity: sha512-kWlqFW7ExvAqKv+X/6ZsWVW7YTmI1/3VUvADLC/6bkLTdKrHS8OtBHfsklXmHMNVbbFopTvoTeKkoqLGrW2lwg==}
+  '@angular/compiler@19.2.20':
+    resolution: {integrity: sha512-LvjE8W58EACgTFaAoqmNe7FRsbvoQ0GvCB/rmm6AEMWx/0W/JBvWkQTrOQlwpoeYOHcMZRGdmPcZoUDwU3JySQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
 
-  '@angular/core@19.2.19':
-    resolution: {integrity: sha512-VZAzpxBoQgyy7AOlhxbAHxPQWo0nk8xsnrD36PLCZeTZA/5GNzO3lLVaX2N5BCUgpgiCBjNBKq9kVo6ZkAls9g==}
+  '@angular/core@19.2.20':
+    resolution: {integrity: sha512-pxzQh8ouqfE57lJlXjIzXFuRETwkfMVwS+NFCfv2yh01Qtx+vymO8ZClcJMgLPfBYinhBYX+hrRYVSa1nzlkRQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     peerDependencies:
       rxjs: ^6.5.3 || ^7.4.0
       zone.js: ~0.15.0
 
-  '@angular/forms@19.2.19':
-    resolution: {integrity: sha512-J09++utTVaPs962y/adeDjIgqyhzNpnzAS7Nex+HNy/LnWPcTNW781cOh1EGS1X/+CmgnI8HWs5z4KGeBeU1aA==}
+  '@angular/forms@19.2.20':
+    resolution: {integrity: sha512-agi7InbMzop1jrud6L7SlNwnZk3iNolORcFIwBQMvKxLkcJ+ttbSYuM0KAw56IundWHf4dL9GP4cSygm4kUeFA==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     peerDependencies:
-      '@angular/common': 19.2.19
-      '@angular/core': 19.2.19
-      '@angular/platform-browser': 19.2.19
+      '@angular/common': 19.2.20
+      '@angular/core': 19.2.20
+      '@angular/platform-browser': 19.2.20
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/language-service@19.2.19':
-    resolution: {integrity: sha512-sCR4vC1tH1t3MW9aKD2K6SEUEJ7jSteWuyVEspgtulGgM9tjXY4gP6f2f6Kq9O76D+MpTR1D1Gb4dEt3M1NM8w==}
+  '@angular/language-service@19.2.20':
+    resolution: {integrity: sha512-kVZR9+8jjJxVQhdzmZlHE4B06qQI56MSupmVvUEBA9d8BeLm1Bai4fqtVvRBj/t8uPsR9klVn1X/rImtwprppg==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
 
-  '@angular/platform-browser-dynamic@19.2.19':
-    resolution: {integrity: sha512-u8aYmIRGtx4yOXhmqgiRIm+DyH+05bAkzMHr6RE0JV/wxVJmAIKZnquHM6ItFvF0eV0pfMTPwArmRuHVWu7tQg==}
+  '@angular/platform-browser-dynamic@19.2.20':
+    resolution: {integrity: sha512-bNuykQy/MrDeARqvDPf6bqx+m1Qqanep7FhDy9QYWxfqz7D++/phqT9l8Ubj88juFCSDfR5ktUWdpnDz3/BCfA==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     peerDependencies:
-      '@angular/common': 19.2.19
-      '@angular/compiler': 19.2.19
-      '@angular/core': 19.2.19
-      '@angular/platform-browser': 19.2.19
+      '@angular/common': 19.2.20
+      '@angular/compiler': 19.2.20
+      '@angular/core': 19.2.20
+      '@angular/platform-browser': 19.2.20
 
-  '@angular/platform-browser@19.2.19':
-    resolution: {integrity: sha512-bnQSmoJNI1LQxJnHnB01XQXqgOdgAtLAOsa24ZT6b2pWV3Vw0/7+V2dZsNZX/TJtejunvSgSDCEqgJhIQ5vBVg==}
+  '@angular/platform-browser@19.2.20':
+    resolution: {integrity: sha512-O9ZoQKILPC1T2c64OASS75XlOLBxY81m5AAgsBKhwiFWq+V28RsO0cnwpi1YSh/z4ryH8Fe7IUFz8jGrsJi3hQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     peerDependencies:
-      '@angular/animations': 19.2.19
-      '@angular/common': 19.2.19
-      '@angular/core': 19.2.19
+      '@angular/animations': 19.2.20
+      '@angular/common': 19.2.20
+      '@angular/core': 19.2.20
     peerDependenciesMeta:
       '@angular/animations':
         optional: true
 
-  '@angular/router@19.2.19':
-    resolution: {integrity: sha512-zh40ihKgYOM5pjgUOLlUKdWYsGgEj7MQHgzdV1E9Zz6LBrQTp/PGS/UdCQn88H6KAshR0uXrkc/vP+tnB2jqdg==}
+  '@angular/router@19.2.20':
+    resolution: {integrity: sha512-y0fyKycxJHr82kxXKE50Vac5hPn5Kx3gw9CfqyEuwJ9VQzEixDljU+chrQK4Wods14jJn9Tt2ncNPGH1rLya3Q==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     peerDependencies:
-      '@angular/common': 19.2.19
-      '@angular/core': 19.2.19
-      '@angular/platform-browser': 19.2.19
+      '@angular/common': 19.2.20
+      '@angular/core': 19.2.20
+      '@angular/platform-browser': 19.2.20
       rxjs: ^6.5.3 || ^7.4.0
 
   '@aws-crypto/crc32@5.2.0':
@@ -444,115 +436,115 @@ packages:
     resolution: {integrity: sha512-ag7Qx78m1K3Dv7xlFgeHS4jBdopGZUISgVBMUy7Cj4fIgVH9EBmsc5K4hWozL8BJQctWke8Wsl96O7Gd+HCGhg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.973.18':
-    resolution: {integrity: sha512-GUIlegfcK2LO1J2Y98sCJy63rQSiLiDOgVw7HiHPRqfI2vb3XozTVqemwO0VSGXp54ngCnAQz0Lf0YPCBINNxA==}
+  '@aws-sdk/core@3.973.20':
+    resolution: {integrity: sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.16':
-    resolution: {integrity: sha512-HrdtnadvTGAQUr18sPzGlE5El3ICphnH6SU7UQOMOWFgRKbTRNN8msTxM4emzguUso9CzaHU2xy5ctSrmK5YNA==}
+  '@aws-sdk/credential-provider-env@3.972.18':
+    resolution: {integrity: sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.18':
-    resolution: {integrity: sha512-NyB6smuZAixND5jZumkpkunQ0voc4Mwgkd+SZ6cvAzIB7gK8HV8Zd4rS8Kn5MmoGgusyNfVGG+RLoYc4yFiw+A==}
+  '@aws-sdk/credential-provider-http@3.972.20':
+    resolution: {integrity: sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.17':
-    resolution: {integrity: sha512-dFqh7nfX43B8dO1aPQHOcjC0SnCJ83H3F+1LoCh3X1P7E7N09I+0/taID0asU6GCddfDExqnEvQtDdkuMe5tKQ==}
+  '@aws-sdk/credential-provider-ini@3.972.20':
+    resolution: {integrity: sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.17':
-    resolution: {integrity: sha512-gf2E5b7LpKb+JX2oQsRIDxdRZjBFZt2olCGlWCdb3vBERbXIPgm2t1R5mEnwd4j0UEO/Tbg5zN2KJbHXttJqwA==}
+  '@aws-sdk/credential-provider-login@3.972.20':
+    resolution: {integrity: sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.18':
-    resolution: {integrity: sha512-ZDJa2gd1xiPg/nBDGhUlat02O8obaDEnICBAVS8qieZ0+nDfaB0Z3ec6gjZj27OqFTjnB/Q5a0GwQwb7rMVViw==}
+  '@aws-sdk/credential-provider-node@3.972.21':
+    resolution: {integrity: sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.16':
-    resolution: {integrity: sha512-n89ibATwnLEg0ZdZmUds5bq8AfBAdoYEDpqP3uzPLaRuGelsKlIvCYSNNvfgGLi8NaHPNNhs1HjJZYbqkW9b+g==}
+  '@aws-sdk/credential-provider-process@3.972.18':
+    resolution: {integrity: sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.17':
-    resolution: {integrity: sha512-wGtte+48xnhnhHMl/MsxzacBPs5A+7JJedjiP452IkHY7vsbYKcvQBqFye8LwdTJVeHtBHv+JFeTscnwepoWGg==}
+  '@aws-sdk/credential-provider-sso@3.972.20':
+    resolution: {integrity: sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.17':
-    resolution: {integrity: sha512-8aiVJh6fTdl8gcyL+sVNcNwTtWpmoFa1Sh7xlj6Z7L/cZ/tYMEBHq44wTYG8Kt0z/PpGNopD89nbj3FHl9QmTA==}
+  '@aws-sdk/credential-provider-web-identity@3.972.20':
+    resolution: {integrity: sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/eventstream-handler-node@3.972.10':
-    resolution: {integrity: sha512-g2Z9s6Y4iNh0wICaEqutgYgt/Pmhv5Ev9G3eKGFe2w9VuZDhc76vYdop6I5OocmpHV79d4TuLG+JWg5rQIVDVA==}
+  '@aws-sdk/eventstream-handler-node@3.972.11':
+    resolution: {integrity: sha512-2IrLrOruRr1NhTK0vguBL1gCWv1pu4bf4KaqpsA+/vCJpFEbvXFawn71GvCzk1wyjnDUsemtKypqoKGv4cSGbA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-eventstream@3.972.7':
-    resolution: {integrity: sha512-VWndapHYCfwLgPpCb/xwlMKG4imhFzKJzZcKOEioGn7OHY+6gdr0K7oqy1HZgbLa3ACznZ9fku+DzmAi8fUC0g==}
+  '@aws-sdk/middleware-eventstream@3.972.8':
+    resolution: {integrity: sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-host-header@3.972.7':
-    resolution: {integrity: sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==}
+  '@aws-sdk/middleware-host-header@3.972.8':
+    resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-logger@3.972.7':
-    resolution: {integrity: sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==}
+  '@aws-sdk/middleware-logger@3.972.8':
+    resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-recursion-detection@3.972.7':
-    resolution: {integrity: sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==}
+  '@aws-sdk/middleware-recursion-detection@3.972.8':
+    resolution: {integrity: sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.19':
-    resolution: {integrity: sha512-Km90fcXt3W/iqujHzuM6IaDkYCj73gsYufcuWXApWdzoTy6KGk8fnchAjePMARU0xegIR3K4N3yIo1vy7OVe8A==}
+  '@aws-sdk/middleware-user-agent@3.972.21':
+    resolution: {integrity: sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-websocket@3.972.12':
-    resolution: {integrity: sha512-iyPP6FVDKe/5wy5ojC0akpDFG1vX3FeCUU47JuwN8xfvT66xlEI8qUJZPtN55TJVFzzWZJpWL78eqUE31md08Q==}
+  '@aws-sdk/middleware-websocket@3.972.13':
+    resolution: {integrity: sha512-Gp6EWIqHX5wmsOR5ZxWyyzEU8P0xBdSxkm6VHEwXwBqScKZ7QWRoj6ZmHpr+S44EYb5tuzGya4ottsogSu2W3A==}
     engines: {node: '>= 14.0.0'}
 
   '@aws-sdk/nested-clients@3.994.0':
     resolution: {integrity: sha512-12Iv+U3qPBiKT6A2QKe0obkubxyGH90hyJIrht1KLxoz5OcIdWYafD7FtVGMwTtYRO73lvnVAsAkNkauZeupGQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.7':
-    resolution: {integrity: sha512-MlGWA8uPaOs5AiTZ5JLM4uuWDm9EEAnm9cqwvqQIc6kEgel/8s1BaOWm9QgUcfc9K8qd7KkC3n43yDbeXOA2tg==}
+  '@aws-sdk/nested-clients@3.996.10':
+    resolution: {integrity: sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.7':
-    resolution: {integrity: sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==}
+  '@aws-sdk/region-config-resolver@3.972.8':
+    resolution: {integrity: sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1004.0':
-    resolution: {integrity: sha512-j9BwZZId9sFp+4GPhf6KrwO8Tben2sXibZA8D1vv2I1zBdvkUHcBA2g4pkqIpTRalMTLC0NPkBPX0gERxfy/iA==}
+  '@aws-sdk/token-providers@3.1009.0':
+    resolution: {integrity: sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.994.0':
     resolution: {integrity: sha512-Dm/MpsQ+aQs2+XDLbA928b8Ly1O0Pz7laTjX52mEah3xyd9/L3UghKSZ7XeLA65PElUp92Seei/bwhKX+KsfMw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.973.5':
-    resolution: {integrity: sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==}
+  '@aws-sdk/types@3.973.6':
+    resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.994.0':
     resolution: {integrity: sha512-L2obUBw4ACMMd1F/SG5LdfPyZ0xJNs9Maifwr3w0uWO+4YvHmk9FfRskfSfE/SLZ9S387oSZ+1xiP7BfVCP/Og==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-endpoints@3.996.4':
-    resolution: {integrity: sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==}
+  '@aws-sdk/util-endpoints@3.996.5':
+    resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-format-url@3.972.7':
-    resolution: {integrity: sha512-V+PbnWfUl93GuFwsOHsAq7hY/fnm9kElRqR8IexIJr5Rvif9e614X5sGSyz3mVSf1YAZ+VTy63W1/pGdA55zyA==}
+  '@aws-sdk/util-format-url@3.972.8':
+    resolution: {integrity: sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-locate-window@3.893.0':
-    resolution: {integrity: sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-user-agent-browser@3.972.7':
-    resolution: {integrity: sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==}
+  '@aws-sdk/util-user-agent-browser@3.972.8':
+    resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
 
-  '@aws-sdk/util-user-agent-node@3.973.4':
-    resolution: {integrity: sha512-uqKeLqZ9D3nQjH7HGIERNXK9qnSpUK08l4MlJ5/NZqSSdeJsVANYp437EM9sEzwU28c2xfj2V6qlkqzsgtKs6Q==}
+  '@aws-sdk/util-user-agent-node@3.973.7':
+    resolution: {integrity: sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -560,20 +552,20 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/xml-builder@3.972.10':
-    resolution: {integrity: sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==}
+  '@aws-sdk/xml-builder@3.972.11':
+    resolution: {integrity: sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws/lambda-invoke-store@0.2.3':
-    resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
-  '@babel/code-frame@7.27.1':
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.4':
-    resolution: {integrity: sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==}
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.26.10':
@@ -584,16 +576,12 @@ packages:
     resolution: {integrity: sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.28.4':
-    resolution: {integrity: sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.26.10':
     resolution: {integrity: sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.28.5':
-    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.25.9':
@@ -604,24 +592,24 @@ packages:
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-create-class-features-plugin@7.28.3':
-    resolution: {integrity: sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-create-regexp-features-plugin@7.27.1':
-    resolution: {integrity: sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==}
+  '@babel/helper-create-class-features-plugin@7.28.6':
+    resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-define-polyfill-provider@0.6.5':
-    resolution: {integrity: sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==}
+  '@babel/helper-create-regexp-features-plugin@7.28.5':
+    resolution: {integrity: sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-define-polyfill-provider@0.6.7':
+    resolution: {integrity: sha512-6Fqi8MtQ/PweQ9xvux65emkLQ83uB+qAVtfHkC9UodyHMIZdxNI01HjLCLUtybElp2KY2XNE0nOgyP1E1vXw9w==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
@@ -629,16 +617,16 @@ packages:
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-member-expression-to-functions@7.27.1':
-    resolution: {integrity: sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==}
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -647,8 +635,8 @@ packages:
     resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-plugin-utils@7.27.1':
-    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-remap-async-to-generator@7.27.1':
@@ -657,8 +645,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-replace-supers@7.27.1':
-    resolution: {integrity: sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==}
+  '@babel/helper-replace-supers@7.28.6':
+    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -683,16 +671,16 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-wrap-function@7.28.3':
-    resolution: {integrity: sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==}
+  '@babel/helper-wrap-function@7.28.6':
+    resolution: {integrity: sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.4':
-    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
+  '@babel/helpers@7.28.6':
+    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -720,8 +708,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.13.0
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3':
-    resolution: {integrity: sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==}
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6':
+    resolution: {integrity: sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -732,8 +720,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-import-assertions@7.27.1':
-    resolution: {integrity: sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==}
+  '@babel/plugin-syntax-import-assertions@7.28.6':
+    resolution: {integrity: sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -744,8 +732,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-import-attributes@7.27.1':
-    resolution: {integrity: sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==}
+  '@babel/plugin-syntax-import-attributes@7.28.6':
+    resolution: {integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -768,12 +756,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0':
-    resolution: {integrity: sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-async-to-generator@7.25.9':
     resolution: {integrity: sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==}
     engines: {node: '>=6.9.0'}
@@ -786,44 +768,44 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-block-scoping@7.28.4':
-    resolution: {integrity: sha512-1yxmvN0MJHOhPVmAsmoW5liWwoILobu/d/ShymZmj867bAdxGbehIrew1DuLpw2Ukv+qDSSPQdYW1dLNE7t11A==}
+  '@babel/plugin-transform-block-scoping@7.28.6':
+    resolution: {integrity: sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-class-properties@7.27.1':
-    resolution: {integrity: sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==}
+  '@babel/plugin-transform-class-properties@7.28.6':
+    resolution: {integrity: sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-class-static-block@7.28.3':
-    resolution: {integrity: sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==}
+  '@babel/plugin-transform-class-static-block@7.28.6':
+    resolution: {integrity: sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
 
-  '@babel/plugin-transform-classes@7.28.4':
-    resolution: {integrity: sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==}
+  '@babel/plugin-transform-classes@7.28.6':
+    resolution: {integrity: sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-computed-properties@7.27.1':
-    resolution: {integrity: sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==}
+  '@babel/plugin-transform-computed-properties@7.28.6':
+    resolution: {integrity: sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-destructuring@7.28.0':
-    resolution: {integrity: sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==}
+  '@babel/plugin-transform-destructuring@7.28.5':
+    resolution: {integrity: sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-dotall-regex@7.27.1':
-    resolution: {integrity: sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==}
+  '@babel/plugin-transform-dotall-regex@7.28.6':
+    resolution: {integrity: sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -834,8 +816,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1':
-    resolution: {integrity: sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==}
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0':
+    resolution: {integrity: sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -846,8 +828,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-exponentiation-operator@7.27.1':
-    resolution: {integrity: sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==}
+  '@babel/plugin-transform-exponentiation-operator@7.28.6':
+    resolution: {integrity: sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -870,8 +852,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-json-strings@7.27.1':
-    resolution: {integrity: sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==}
+  '@babel/plugin-transform-json-strings@7.28.6':
+    resolution: {integrity: sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -882,8 +864,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-logical-assignment-operators@7.27.1':
-    resolution: {integrity: sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==}
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6':
+    resolution: {integrity: sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -900,14 +882,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-commonjs@7.27.1':
-    resolution: {integrity: sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==}
+  '@babel/plugin-transform-modules-commonjs@7.28.6':
+    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.27.1':
-    resolution: {integrity: sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==}
+  '@babel/plugin-transform-modules-systemjs@7.29.0':
+    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -918,8 +900,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1':
-    resolution: {integrity: sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==}
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0':
+    resolution: {integrity: sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -930,20 +912,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1':
-    resolution: {integrity: sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==}
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6':
+    resolution: {integrity: sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-numeric-separator@7.27.1':
-    resolution: {integrity: sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==}
+  '@babel/plugin-transform-numeric-separator@7.28.6':
+    resolution: {integrity: sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-object-rest-spread@7.28.4':
-    resolution: {integrity: sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==}
+  '@babel/plugin-transform-object-rest-spread@7.28.6':
+    resolution: {integrity: sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -954,14 +936,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-optional-catch-binding@7.27.1':
-    resolution: {integrity: sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==}
+  '@babel/plugin-transform-optional-catch-binding@7.28.6':
+    resolution: {integrity: sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-optional-chaining@7.27.1':
-    resolution: {integrity: sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==}
+  '@babel/plugin-transform-optional-chaining@7.28.6':
+    resolution: {integrity: sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -972,14 +954,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-private-methods@7.27.1':
-    resolution: {integrity: sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==}
+  '@babel/plugin-transform-private-methods@7.28.6':
+    resolution: {integrity: sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-private-property-in-object@7.27.1':
-    resolution: {integrity: sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==}
+  '@babel/plugin-transform-private-property-in-object@7.28.6':
+    resolution: {integrity: sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -990,14 +972,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-regenerator@7.28.4':
-    resolution: {integrity: sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==}
+  '@babel/plugin-transform-regenerator@7.29.0':
+    resolution: {integrity: sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-regexp-modifiers@7.27.1':
-    resolution: {integrity: sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==}
+  '@babel/plugin-transform-regexp-modifiers@7.28.6':
+    resolution: {integrity: sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1020,8 +1002,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-spread@7.27.1':
-    resolution: {integrity: sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==}
+  '@babel/plugin-transform-spread@7.28.6':
+    resolution: {integrity: sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1050,8 +1032,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-unicode-property-regex@7.27.1':
-    resolution: {integrity: sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==}
+  '@babel/plugin-transform-unicode-property-regex@7.28.6':
+    resolution: {integrity: sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1062,8 +1044,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-unicode-sets-regex@7.27.1':
-    resolution: {integrity: sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==}
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6':
+    resolution: {integrity: sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1083,21 +1065,24 @@ packages:
     resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.5':
-    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@ckeditor/ckeditor-cloud-services-collaboration@53.0.3':
     resolution: {integrity: sha512-j0JBOgTNEDbnUadaL7ODG3khiZaGuVFZ+NwYRNy5MG1+UVsRNbZh4ch4GvBe3KTeAI16p5EZlQZATBpkeVkwoA==}
@@ -1105,481 +1090,297 @@ packages:
       '@ckeditor/ckeditor5-utils': '>= 37.0 || ^0.0.0-nightly || ^0.0.0-internal'
       ckeditor5: '>= 37.0.0 || ^0.0.0-nightly || ^0.0.0-internal'
 
-  '@ckeditor/ckeditor5-adapter-ckfinder@47.2.0':
-    resolution: {integrity: sha512-zzuINBzWuheU76Ans9m59VCVMiljESoKxzpMh0aYu+M3YB5IDctOPU8pdOpXPIdBwoYv64+ioZE/T5TyZDckSw==}
+  '@ckeditor/ckeditor5-adapter-ckfinder@47.6.1':
+    resolution: {integrity: sha512-X4l4KyLgSsmAyRd/YY8R/OArOXR2Ts8NyoW6k+tLtYxEmZOhJsa6ZFSho/OVTole7IqMl+Zo93b9YaAwX23brw==}
 
-  '@ckeditor/ckeditor5-adapter-ckfinder@47.6.0':
-    resolution: {integrity: sha512-SMGuLMvXlNK9NjKL24zjV1JK3KCQxMoafTFEW5iGiKA63g9GNmhVhpu56dT+9bRpOzDNchnSYW9ljuW04bDr4g==}
+  '@ckeditor/ckeditor5-ai@47.6.1':
+    resolution: {integrity: sha512-raNc9uiLEGZCjF9HWQTGu2HRfPDezZHC5KURFEgYrVyc0KL61bhGi1hXw0rpn0qNUF42yuDuUwtwK+Vo3wgq0w==}
 
-  '@ckeditor/ckeditor5-ai@47.6.0':
-    resolution: {integrity: sha512-ry1hoEDLGcrpsQipG/0SPL4rVqsllFsBOeZeELm+B6i78dzb2vZpOnGiOqXjR3uJQU1G6lQve70qHCv4CDQvOA==}
+  '@ckeditor/ckeditor5-alignment@47.6.1':
+    resolution: {integrity: sha512-2u1+Eseelrm5gKKajE9X+gcPchVAIna3AkoJyCw3+Y4dBc6ElWZJEuCO7b6Omv5H7q3lQimbaqJnvIE1Z/nXOA==}
 
-  '@ckeditor/ckeditor5-alignment@47.2.0':
-    resolution: {integrity: sha512-lfcJAC8yJOQux3t33ikJrWRsZvywLr2zmU6mDR96SuCmeCyAN3UGXzCNa8kWPExpFGV01ZR61EZkjTah8LP2sQ==}
+  '@ckeditor/ckeditor5-autoformat@47.6.1':
+    resolution: {integrity: sha512-UI3HFyw7VCTM92IhE6hdIh5rp2nqOLL4vnnOFTgp7Lq6dLOVzuwsRJLIEfYxz4Xusy4UKu4zM8QX4FV1nOWsGQ==}
 
-  '@ckeditor/ckeditor5-alignment@47.6.0':
-    resolution: {integrity: sha512-vfu+Hsza8kW0ehf+7N1hibmWRQpJ84CTPWjM9PNtwb+irvnQ3WjAK8D0fw9dY+ZM7FtPCT9xJGCDCI5MoRZ/fA==}
+  '@ckeditor/ckeditor5-autosave@47.6.1':
+    resolution: {integrity: sha512-7om5OHf2hBDi/Md8lVZL6fF7gCBAMVZfg8zsJqTmAW6fwl5gfenD4rggPdSa4GVt+mZXbheZx9EWc0HX1psAew==}
 
-  '@ckeditor/ckeditor5-autoformat@47.2.0':
-    resolution: {integrity: sha512-d9ZwAB8JwWlgLK2Um+u3ctiCtv5bkBHGk/rSdXB6D/V7QHCl31NyPFYByxTyCOY9SsoNn1l/8zbJfvp89LJm2w==}
+  '@ckeditor/ckeditor5-basic-styles@47.6.1':
+    resolution: {integrity: sha512-/8R59UxR/8quK8UmOLOS1xq47GnB+oMNySo8BgLHJl7qepRR5VnWU0hHB239idnFk46IVhuRciXQHjifrJiScQ==}
 
-  '@ckeditor/ckeditor5-autoformat@47.6.0':
-    resolution: {integrity: sha512-idBf0RsdKr1sIcaupIqHksx6VPzGtCsKi4ZjAfFl4syVCvx3lPpJselkkvsdpTmw0Rqg4x8zyfMGElSL82SXuA==}
+  '@ckeditor/ckeditor5-block-quote@47.6.1':
+    resolution: {integrity: sha512-wyDLqGrmcDVNlRmHxXTpXg2PKImgB4yIU3UDRofFKVJiuvnZvKKvx/Oh9USVv1G1zOAPoFyoK9AQzqYNOB7AMQ==}
 
-  '@ckeditor/ckeditor5-autosave@47.2.0':
-    resolution: {integrity: sha512-44nGL/M0qLURA1BEFkqZg6JzpjtvGyWJEluv728vb29JNQUGx0iNykjHBgtPX5s1Ztblx5ZwqFiuNiLkpmHptg==}
+  '@ckeditor/ckeditor5-bookmark@47.6.1':
+    resolution: {integrity: sha512-9HwVudGBEhbqMPkEXQTqSIACGYpOWlES7bOxdG6WfgOUOAdCiTPXFCc5f+HSMFbrwd7XJ40tycPLOa7XK14oEg==}
 
-  '@ckeditor/ckeditor5-autosave@47.6.0':
-    resolution: {integrity: sha512-bU7E14bu/8paefBMtOT61P5V95fdafaG3OQXdnE5tHD7jrualznuEzek519U5VzL8Gh1Wo4cHyLA2pg1Ljyb/A==}
+  '@ckeditor/ckeditor5-case-change@47.6.1':
+    resolution: {integrity: sha512-B/6OczzVBsFgyQW0SjK2HylVe6SjDfShwJdcL3QRxFv6FefzkB5UbU4nChGTzLm7Xy6cOP7CyVsBKCDqFmirfQ==}
 
-  '@ckeditor/ckeditor5-basic-styles@47.2.0':
-    resolution: {integrity: sha512-a8pPHq3CXmyxPPXPQZ8C92OOyBoCfpY8M30dS7et/dLXW3nuVo9VVLMw0vR1j+zcKXClp3+/odyw2/rxP+qntA==}
+  '@ckeditor/ckeditor5-ckbox@47.6.1':
+    resolution: {integrity: sha512-v083Tnbsx4z1fFW+ghMXlsf5EgB3UaSldjfRsipjIYUiUeatccgRN00Qh6qGMlYz7zZcSdUUtrOfTWL/LYPWDg==}
 
-  '@ckeditor/ckeditor5-basic-styles@47.6.0':
-    resolution: {integrity: sha512-GYYO//eNp13ZGn7Fg7s9eSdaDLt/Hut6efC8gTkakfx2yCZqcjzjV4gBJmvaIul1hw+EzsMjBhYe4lorBAM5oA==}
+  '@ckeditor/ckeditor5-ckfinder@47.6.1':
+    resolution: {integrity: sha512-ewgqgtQaDDZHQUGby/gg2/840Go280bvx959ExQH8Y7u4fPVw8NEFYAxjcm43W6EXgMnlmsEr8+G8q8g4iKT1w==}
 
-  '@ckeditor/ckeditor5-block-quote@47.2.0':
-    resolution: {integrity: sha512-BlFFfunyWpYcGhLsOmCR0yEz5VgrOmHREHQZIRcL6fKzXJwdpA/VFWPirotwF/QErJjguhhDZ5a3PBEnUAmW/A==}
+  '@ckeditor/ckeditor5-clipboard@47.6.1':
+    resolution: {integrity: sha512-F3KQuCnnCavm8wXvX+d1KN/obh5ux/jT9qC/71QfMKdDvHxEOzi/t3YWa1r3sztlksDQ4LtODU4uWh0vVKUpkg==}
 
-  '@ckeditor/ckeditor5-block-quote@47.6.0':
-    resolution: {integrity: sha512-xFydZ2+1tcv5TcqoWPtlDJ0wntujOJfIrXncqDe6wXXe/ByK5/wJu2d88XxLQFCNvn3BjP9VLBQNrKIAlpFM1A==}
+  '@ckeditor/ckeditor5-cloud-services@47.6.1':
+    resolution: {integrity: sha512-yC9aqornbxjgNhHuUX4gcuvPTLv34sc8CbUOeFYLGbD9ujwoC0fzzjzSB7u5b8fWNg6cAjzriFooJATHBvu40g==}
 
-  '@ckeditor/ckeditor5-bookmark@47.2.0':
-    resolution: {integrity: sha512-FDFDZXm8MqktIt3x0WVrYFuXy9sxcCH31Cpa0/mV19lW8CzoCZCAfvXNzPWsz2eFo8qOsna2c/e55ax8OM/Ncg==}
+  '@ckeditor/ckeditor5-code-block@47.6.1':
+    resolution: {integrity: sha512-ntZBIEYLoC4/OTUgCkwwmyXwwqDk8QwFcx/1kZN7S4YtwocREZqpDH1wYT+GA2ZmGkjaBRxdTLwSVr/7bf+wqg==}
 
-  '@ckeditor/ckeditor5-bookmark@47.6.0':
-    resolution: {integrity: sha512-Bkxh46mHCEYM9cOSJjK6NpHtBpSyJWqYVyTrLl24SiixtHUpuXqFKKM7Jo23GjcuPBXVSdG2ax6iwUCzcFuHAg==}
+  '@ckeditor/ckeditor5-collaboration-core@47.6.1':
+    resolution: {integrity: sha512-TcUyOC+CpH45nbiw684tUNiBMZStKTkjRexG4YBVCMXE/W26nFf/4ISONycPNLCZolFWwFvtPfGsrOLPg7208Q==}
 
-  '@ckeditor/ckeditor5-case-change@47.6.0':
-    resolution: {integrity: sha512-GJqSAoUX5/k29cHvWhUQnoI0K37u2yLaab675M1u167Lv1/WoSPsX7gR9OVRiwsNUKfmJ3/HuL7qJ2l+VaJJQQ==}
+  '@ckeditor/ckeditor5-comments@47.6.1':
+    resolution: {integrity: sha512-cLTMoTsrMiN7jRhU2sl/JPy/YmHckis5P8kxpiXeYNzSXzY9y1tGaNgFsr1j1VIZFm9FTmKRRKqVmx7twALSKA==}
 
-  '@ckeditor/ckeditor5-ckbox@47.2.0':
-    resolution: {integrity: sha512-Cu+nJTXhcmdE8DWHoTY1nrrjxyG4pfxMrEcO/PNV28cojwtOQaWGt4EbWlXOfZZTEWlZO18JIw/YrxYXwx5mTA==}
+  '@ckeditor/ckeditor5-core@47.6.1':
+    resolution: {integrity: sha512-6dtnquhjymLkNhdC9T6gk/Mf2bDnHSTZrhkByaXC96CbmQDriCgfcaAVY6pQgDNxBQ6fZrev0TnKBLfTItrMsg==}
 
-  '@ckeditor/ckeditor5-ckbox@47.6.0':
-    resolution: {integrity: sha512-IOpJZMc8NLe4ruLfG8jfwC84yEbTqn/0rUyKgdmTf6M5ZofpIMyaqSIU30aULBgmaXwkE/hQTbfjgaJ3UUSo5g==}
-
-  '@ckeditor/ckeditor5-ckfinder@47.2.0':
-    resolution: {integrity: sha512-nsxn9weZNwdplW/BHfEJ/rvb+wZj0KECN2Av9zFRekTxE1mp0hTShQ9MNlKImRQ4X2UV6bGN6+DXwJJIU0smlQ==}
-
-  '@ckeditor/ckeditor5-ckfinder@47.6.0':
-    resolution: {integrity: sha512-hCuFkKx/ph5ntmCSvjO7zIxET/pL/5Q1fYt1joOE9hjaBWFMoRao87GUjJ3O751ZAkioSe90zECP8SXYz8ZlIQ==}
-
-  '@ckeditor/ckeditor5-clipboard@47.2.0':
-    resolution: {integrity: sha512-x/ehXk+ga5tnumA8TenrZRU684DvpzzhTLfZScRxX3/3BJPYlFp7BWx60KJPQHKXYgb+I0qkQrgxuBXp83ed2g==}
-
-  '@ckeditor/ckeditor5-clipboard@47.6.0':
-    resolution: {integrity: sha512-ymkOH+O9C+v3vKTaw1iOrlJMti+7Q9ycKdP5bCc9/4ywtR6cRtZ5BnEkbK1S1CSxkijQCdpe+0tNgXI2aniD+A==}
-
-  '@ckeditor/ckeditor5-cloud-services@47.2.0':
-    resolution: {integrity: sha512-794mxJ8MFhz2SxSjlMSp4cZbyBBpVjinQ3GxOS5VqO7H4m/iT2hdSPJaWpML53soxpEoG/6ax4vVKe5d0+xoqA==}
-
-  '@ckeditor/ckeditor5-cloud-services@47.6.0':
-    resolution: {integrity: sha512-8MkrqbfiglNwqkUnfL0uoBZVlHmsqvq6wXiz60fnWTpTiEmxzV95/JeT7toFafvxLO7WSzBjEcZcmc9Z6ChyAw==}
-
-  '@ckeditor/ckeditor5-code-block@47.2.0':
-    resolution: {integrity: sha512-8SH10L7i+wirkouDmg4MdBN4R3AZDyutsuSCwDPALoKSHQs7KlYB+8TJxcejt/dSBd0JWgrBi7rVu9Arkk3I1A==}
-
-  '@ckeditor/ckeditor5-code-block@47.6.0':
-    resolution: {integrity: sha512-SetV7GnNwUOqyaPHlzXgTuT/TrLLhQ9z3glmfIQ4A9BvV9dvP6Nb9vFeJnDHuhEwBauQS8M0DqdFc+F3qdJwsg==}
-
-  '@ckeditor/ckeditor5-collaboration-core@47.6.0':
-    resolution: {integrity: sha512-Xbz/S+uiHZv9SHlahR2Cv6Tjofz4XOZDlSOuAZyVkjhdjiAbIUPUATxERH4KJyiUkr14HkOAWY37ZZ1S1dYX6g==}
-
-  '@ckeditor/ckeditor5-comments@47.6.0':
-    resolution: {integrity: sha512-Mzx0CM+kODEjkla6w1qaiSPFNebSn7XKuPpXlParnb6H8kiDLuTPA/l4kEEuByKEKuqUYFmV7S62nj9N29kQVg==}
-
-  '@ckeditor/ckeditor5-core@47.2.0':
-    resolution: {integrity: sha512-NwUNa25g//ScxaVPASalcGfMDhUSv7nIpxC07oVv99zJjk64RTBr4TZHpjKLCVqN9gAn3phAtjtkxa2KOgOMtQ==}
-
-  '@ckeditor/ckeditor5-core@47.6.0':
-    resolution: {integrity: sha512-kw1zN6Fv5SRiZBSCfJV8yBGmirNC+vnKBOKxiS5I50wRReH90IJnTyh5Fu/vqsmr7UtSR5xvAKhu4xg30MrsRQ==}
-
-  '@ckeditor/ckeditor5-dev-bump-year@54.3.4':
-    resolution: {integrity: sha512-Xben24lWt/weGc3N6iEUBonyFJFEaCbmJ0P+/fggwaxPy8O4zHAE3uW60ErYmtN8ZSA3OEUz/qNHoR7acfS3zQ==}
+  '@ckeditor/ckeditor5-dev-bump-year@54.5.0':
+    resolution: {integrity: sha512-V1le+yC1n6tG7//oWoKQRUtxHx2Hnl9XHb5sNRvt8365mQGpghG8JyTrgSdcJFTqUQB/pQRpqHTnZKuTgxFD3Q==}
     engines: {node: '>=24.11.0', npm: '>=5.7.1'}
 
-  '@ckeditor/ckeditor5-dev-changelog@54.3.4':
-    resolution: {integrity: sha512-pmxrrODJkbVWShKWKsfnxcHGPYwIHjQOsFbVF0+9AAlBUhu03I4kBM0F6PHqHSFI1SlEfguhYZkkhL/UJBRM0g==}
+  '@ckeditor/ckeditor5-dev-changelog@54.5.0':
+    resolution: {integrity: sha512-YtevF+LVkMglauskWYpFaAk//ay8oWmXV4l5tOPHQB8iIwt4QBJhquwX6aKhoUBUjWB0tojOU41ybYmLBRER6g==}
     engines: {node: '>=24.11.0', npm: '>=5.7.1'}
     hasBin: true
 
-  '@ckeditor/ckeditor5-dev-ci@54.3.4':
-    resolution: {integrity: sha512-/Dtku2fFOnceYtexvPcokTJYMjiG11h0/d3Hj7WrpHYBIpVUR3NzWP6ancQFJXSjPK85sqWQwKMmp1Y3pstoAQ==}
+  '@ckeditor/ckeditor5-dev-ci@54.5.0':
+    resolution: {integrity: sha512-3tgA66ub93ECVw4x71LPsN4jbd73hauJMOa5hxqDRiAit9f8Uz3F4D2VI+J0MhrABnJeyOxBmat9EoSYbsKO2Q==}
     engines: {node: '>=24.11.0', npm: '>=5.7.1'}
     hasBin: true
 
-  '@ckeditor/ckeditor5-dev-release-tools@54.3.4':
-    resolution: {integrity: sha512-PwHgn4+2Ofx72IwpYjPxkGKJEpL8+QoxaYGYqRB26zbaGVn/Xd1i1fYqg9Itsp08iRLnqeWo2NdEoOUzQL9k/Q==}
+  '@ckeditor/ckeditor5-dev-release-tools@54.5.0':
+    resolution: {integrity: sha512-BQoDmbwEAz+gEBkjtJjbSdPVaJSTOQOQbnq/PTToAmSxjuNjRbq9vnDQZc30WF/4xddW/mOdO/jXHCR26vLRfA==}
     engines: {node: '>=24.11.0', npm: '>=5.7.1'}
 
-  '@ckeditor/ckeditor5-dev-translations@54.3.4':
-    resolution: {integrity: sha512-bxvbB8Vao0kZ/glaXfm0Xu76Z4NbGE2xpTOX2i4G7Jcawr8KOozx8DVL5rmGJF9xioeZU5JAEod1E5+rbddu2A==}
+  '@ckeditor/ckeditor5-dev-translations@54.5.0':
+    resolution: {integrity: sha512-TyfcdZDlqPy6BgnCoU0JCML8x17q51cuhXo+knRG6OFZ12AEtXNRts0E3gzndMb6RNR9pxFRMQuLxTY2eLlGaA==}
     engines: {node: '>=24.11.0', npm: '>=5.7.1'}
 
-  '@ckeditor/ckeditor5-dev-utils@54.3.4':
-    resolution: {integrity: sha512-zwJTY5t3/zQeDs8Y8E9X9t71XXCPhGjsgSezFlvgIk8J4A5yHQ7YMIQwh67I/6VQ3SCMLO7J05hZSz5V6kFlmA==}
+  '@ckeditor/ckeditor5-dev-utils@54.5.0':
+    resolution: {integrity: sha512-ZDk7NPg8z2RgJ+h7g2tjecmxCs4TVwDtlZYmICxTN7EzdQRRINZ/I/MdsIi2S1ldCflIqFiObjaVTBSlGdhrmA==}
     engines: {node: '>=24.11.0', npm: '>=5.7.1'}
 
-  '@ckeditor/ckeditor5-document-outline@47.6.0':
-    resolution: {integrity: sha512-wh5pR8oiqiDGSMJ8PJJc4iCf228raZ9AHzW9taGP/XOgDCfphfrBEgcjMSFcIqfJT2eXIxiZFulft9d4agaDIA==}
+  '@ckeditor/ckeditor5-document-outline@47.6.1':
+    resolution: {integrity: sha512-zK6MtLfpyxv9VIKrFj5zB5uF1pk2zkGViS3SpPn6UE0opINfbrV2WqKlfbbwzSKgruzTrsH+fbFnKslgHtRI1w==}
 
-  '@ckeditor/ckeditor5-easy-image@47.2.0':
-    resolution: {integrity: sha512-lSnbiGDzYdu9GeOaYjVpowaZWDJbrb7NHCuUN5Af2474jXTDyYmG7qOm39fWEBlcxjMTzDR8fFzPcRNhOvSRRA==}
+  '@ckeditor/ckeditor5-easy-image@47.6.1':
+    resolution: {integrity: sha512-hWaqibO1ZUHRIkvvAO7O0qDAIw+GN6UWbdr0wcGNLc4DcSZMUIpAfoXuiyyvE9hQEJPpfTOwA3r0znS6wXtMCg==}
 
-  '@ckeditor/ckeditor5-easy-image@47.6.0':
-    resolution: {integrity: sha512-hOTxDnCU+d3vp0eKeULQxk3rZRkkZ551OM9O1ZE9sEaOjAdndaikqSH9VEwhSKTfmRIWHrMJg1ouxw2aeHvwHw==}
+  '@ckeditor/ckeditor5-editor-balloon@47.6.1':
+    resolution: {integrity: sha512-geszCykoE9Sja2tBqyMww4etAzAExg4eGnlYbXSGiaUiC7Ks4OqRVeuvw37QsH8Q56J5FQC35ysq95nrLEB+0A==}
 
-  '@ckeditor/ckeditor5-editor-balloon@47.2.0':
-    resolution: {integrity: sha512-szIx59pnw6kgxYuAyqecMnSlwtwWu2q23XV4TpKF/V3NlHs9ZeIFusTX3icO8JLQR4ExsYa0bsYpabGdZdx2Ug==}
+  '@ckeditor/ckeditor5-editor-classic@47.6.1':
+    resolution: {integrity: sha512-w2QaF2ieqLqu6i9YldOpPnFezvAsXY/R/vp/c0D1ofvI1CtBRWhQ9/rRwADMoKgpcuyP2320sRG312anT8aiaA==}
 
-  '@ckeditor/ckeditor5-editor-balloon@47.6.0':
-    resolution: {integrity: sha512-LsnDsovjVrif7mRbdwFJKmKI5q5xmD2Zi/8+ImsCUm6fOo9Q3nmairDoWhQ0Bm1KH1MFDFYCDzZXuiI42T2F8g==}
+  '@ckeditor/ckeditor5-editor-decoupled@47.6.1':
+    resolution: {integrity: sha512-w047UpjHF106k0NeQLgWY03k29s5vIpS9M6Oj+f+IdKaf4TR7uSzl/CXsS+csfqwZEhtGwGV3LYJVzo35+SifA==}
 
-  '@ckeditor/ckeditor5-editor-classic@47.2.0':
-    resolution: {integrity: sha512-fYy4RKmvM4kYvUgCRuBdUqVLE8ts1Kj4q1Caaq5VZyBudmaj/RZqQBSdiu5pZgKMdj1oMaIQ5Gextg96iJ3LTw==}
+  '@ckeditor/ckeditor5-editor-inline@47.6.1':
+    resolution: {integrity: sha512-UJQHbMh1nvsHMuiijmRx3y/5ssdxeJTrVjrwDoPlUsI8tfRYjkdIucd9SsRhXnV65Vk31Ah5wiFyaBb5OLXZaA==}
 
-  '@ckeditor/ckeditor5-editor-classic@47.6.0':
-    resolution: {integrity: sha512-NF+YBnfacILu3+EvsEb5UZvE9llpcO0qfbDdxJUu+t8bHXMhZzo3kOh0Gw3mB3Yil62IVTita0P3AZvzq053zw==}
+  '@ckeditor/ckeditor5-editor-multi-root@47.6.1':
+    resolution: {integrity: sha512-Jn55iVT2sg85NSPVe/mThLoiI0FTAEH5r48MXD1MKz1E5K0FkpdLiKyCR4onfdFLozWZW2NvU0faCkyI0BKaZQ==}
 
-  '@ckeditor/ckeditor5-editor-decoupled@47.2.0':
-    resolution: {integrity: sha512-h1Yw6/XHeEe5aW/4VV0njAGe5nsuIBkARCun039noA+b2bq+Qb9bAExzaSHULf7nZW4HHVJMcYvb2HwcX8MZ6g==}
+  '@ckeditor/ckeditor5-email@47.6.1':
+    resolution: {integrity: sha512-OqYd63dJJuu9KCUrb17geeiw1gcWkpYQyCcoiJEoyCZLXAPmGmECeCrdTvoI7f7d0/BttBWaSN9Y6rrN2fwMWQ==}
 
-  '@ckeditor/ckeditor5-editor-decoupled@47.6.0':
-    resolution: {integrity: sha512-BgwJZUJEzR06bLf1Qk6Klilaacumk4uMZCAdQCCg4LSMNAk3eaQgccl6SUZqUH9V/NDpogIGcaDbUPWvuxJKjQ==}
+  '@ckeditor/ckeditor5-emoji@47.6.1':
+    resolution: {integrity: sha512-bnnnvRk/eYrvKLLQpJrjSV++Abpm1/8N31BNVaZyeHzaI0pddE6ikS44Ju82u7BQJaqSi2SO2Glx3u3C14rm2g==}
 
-  '@ckeditor/ckeditor5-editor-inline@47.2.0':
-    resolution: {integrity: sha512-6kGG8Q4ggOim7KU/J3iMvmf5/faNjYL/ucg2RPMvzhH/eTqlZBlMdDid86b0YAW0fbKPvIIACifoOBHIGlcZyA==}
+  '@ckeditor/ckeditor5-engine@47.6.1':
+    resolution: {integrity: sha512-Xb398PRhkJqtUuQ1E1pdLXTG1REIOanr7PCIRPpWvpHAIZZAuxTIqyacZC4qVTS9xI+ObxYqosf8yNvFsEtu8w==}
 
-  '@ckeditor/ckeditor5-editor-inline@47.6.0':
-    resolution: {integrity: sha512-89B+SYsuI64mfu/qtIyYarw0qSmripIA33L3FaH6KUJpPBwwIjd5huZg6L5BXE6ZuPMGyRjRq6JapQb0zExWEQ==}
+  '@ckeditor/ckeditor5-enter@47.6.1':
+    resolution: {integrity: sha512-H/d5L8JmZFmb5wYDi3NT4NICYuRueGUwiPgIpaaQ0gb8U3U0YVj4J5WVF/65KGiYdsuP2NupSwRqsdl8TilrdQ==}
 
-  '@ckeditor/ckeditor5-editor-multi-root@47.2.0':
-    resolution: {integrity: sha512-bIkPzkpLGznNnDLAuSkVNP+LfICLbUj80IdkVLB9KeXnuZ1WKYkLqBGfDv6y70iJnANAiiP6Z8EaucBNzfjS7g==}
+  '@ckeditor/ckeditor5-essentials@47.6.1':
+    resolution: {integrity: sha512-4A9E9GrOudYA/eWCXE9uLqEdw7RLO/OdmeY1KWGAF6B9fubieSCF+S69M3c5hMKS6KJoNjaVJ/iR91KfIyYmtw==}
 
-  '@ckeditor/ckeditor5-editor-multi-root@47.6.0':
-    resolution: {integrity: sha512-uA5JPlV7QFfMVErqoVdwLJbUoF/u3X3GGg5s+VMeVoVTnn3ZQ8592HVftuT87HIiI8W1NHdlrE/32+3iTnOoVA==}
+  '@ckeditor/ckeditor5-export-inline-styles@47.6.1':
+    resolution: {integrity: sha512-ryy4gcWqeSMHLEw9q/caqlTBOFMqUSSRtdPKw5n7P2+AReVz2bX0gMJFk913jrSLWh1v5ErqAqlB37PfCZLLUQ==}
 
-  '@ckeditor/ckeditor5-email@47.6.0':
-    resolution: {integrity: sha512-Kdg5Vbstjo71LM6SLzWD/Gy/X4ysbDNOH3bgAa17nrx7CGPGlSkDWDdmqrsbaP9P2Pr1K5szM3hpRPOYgLvtaQ==}
+  '@ckeditor/ckeditor5-export-pdf@47.6.1':
+    resolution: {integrity: sha512-Q7/uAKSCwen33mBAiTg5/dhnfmcr1BWZxX0PpbRAjlO5NrFXCd7EuQuoWZQEoC5d1N13yEBk5YqueoaFxHUTXw==}
 
-  '@ckeditor/ckeditor5-emoji@47.2.0':
-    resolution: {integrity: sha512-pS1G0QVFOK2Z+BLrVmm6pVjFZRpkC95YgQeASuuIySLZBllYD3+tlys2lPt3el5PAd0IQB7s85XuTdbCXDFr6A==}
+  '@ckeditor/ckeditor5-export-word@47.6.1':
+    resolution: {integrity: sha512-RQPtKANSeUxMbGHuG7skX88b6CQ919ToC+yUkP3ZHn/lvvNpcR6CWDHN0PwRHIGJNVc1ifCapZAOXMO7Jg3yhA==}
 
-  '@ckeditor/ckeditor5-emoji@47.6.0':
-    resolution: {integrity: sha512-DLoScPQAMKXpe6U3M6Dw2sed0ElQeMgun0B/j//EfBPdtqkY3IDPg/R7SlRxsYuYNf0cEWNZwaNnlL/JI6w+gA==}
+  '@ckeditor/ckeditor5-find-and-replace@47.6.1':
+    resolution: {integrity: sha512-ZbKlNpFYCP0DRICJlhyTLaRlPSwdJ5W9BBrMFjHhGsKNbFJ2KHlPCqTD6nAEWc838heDBZM21jRGTM6O92FLHA==}
 
-  '@ckeditor/ckeditor5-engine@47.2.0':
-    resolution: {integrity: sha512-T3pFgycam60ytkbLOo2r99UPkbalLfzp4e6QrDVdZnloY7BO46zAbU5p3TqgfCdxODPhZh7srFGzANh6IsLMeg==}
+  '@ckeditor/ckeditor5-font@47.6.1':
+    resolution: {integrity: sha512-ayMtG44tLbmPBjoEudnF7kFkqX3GUO0Cb1lLd6JR5B4uyoNFuQbN3nyrtx7hMvdu0N4jl0hWcWXjdu6vNL4I6g==}
 
-  '@ckeditor/ckeditor5-engine@47.6.0':
-    resolution: {integrity: sha512-HjtlviZZhPDSfHS7aEYUfhVuEWCHCyjCUDd4r4vx9A+02W7G+Gg6I0lqtDqTRL/Bp5rVv3MeRrcaYU21jCFJ3Q==}
+  '@ckeditor/ckeditor5-footnotes@47.6.1':
+    resolution: {integrity: sha512-dig0MLBWUiFKk/OhElD0A2HOvjLwCvZlZH4r0CXFiRAuC04LGsmVOsOnpb3M/qnIxpPt0EQMNJn7PxXd+DVRdg==}
 
-  '@ckeditor/ckeditor5-enter@47.2.0':
-    resolution: {integrity: sha512-7ZHfrxDSs55IXgs5yAX6Nl8COY1dqefZ5HiWT/UM0cOP/4aMffp5I1yYYP7NVfBkTW9DlUoeAkHFTv2miTwclQ==}
+  '@ckeditor/ckeditor5-format-painter@47.6.1':
+    resolution: {integrity: sha512-G8w4HWbweMESBBBsKC3HXLwhJ04gvksqOq1PTXpCe1p0uI6/baBUZs74A8mrgm2zHrHwFM+tB99qoIfBoyA4Ow==}
 
-  '@ckeditor/ckeditor5-enter@47.6.0':
-    resolution: {integrity: sha512-+WlxCGj4J+Q+BFyAWkJZ6q+t4LnDHEstQtYFT5pGj23oUSVeOBzc+7e5FqU4LLtOzYnClN7t98OGPDPOHHhS9w==}
+  '@ckeditor/ckeditor5-fullscreen@47.6.1':
+    resolution: {integrity: sha512-LvA7vzeAkuc/z64kuRu17zm7EIFe0Bqt9xPA5GhfR6T9mBVG4wu62ElqylFUjFJ+macvkjSe68tBYQTAPyUWqg==}
 
-  '@ckeditor/ckeditor5-essentials@47.2.0':
-    resolution: {integrity: sha512-d3hHtkuLhvI+RvsDU7cKFc/K9uD27Tvi4NVjALcN1Ybr0k8dkJFGU1nUwXuo6zcdqRnkIJMWxIR+cwteuMCGQg==}
+  '@ckeditor/ckeditor5-heading@47.6.1':
+    resolution: {integrity: sha512-4kVuMaaAylkxYkJ0PA4hUQCDTARoeokkqKh0dE3DwEZTvvWDZjBEAhIKaSVX116ByeGfImbLkBRAoNCljKNCHQ==}
 
-  '@ckeditor/ckeditor5-essentials@47.6.0':
-    resolution: {integrity: sha512-rI5/FWOcMjGVtWlHisBQCtL88pCZJiB+SwpmpumdALqP99urUqbL8tFprwyv95r7o4sFPMymJYVdHGlUjKb4Dw==}
+  '@ckeditor/ckeditor5-highlight@47.6.1':
+    resolution: {integrity: sha512-hEIAZAImLAGRsz7/d+bbh3k+9s854AxuYoTmCAN2u07muYX/pmrLrLm6cZcazjmi9J/Bow6sP/D5GeoYMWKkLA==}
 
-  '@ckeditor/ckeditor5-export-inline-styles@47.6.0':
-    resolution: {integrity: sha512-REx2MODdhQcm8VCfFcVoqtohaVp7Vczllu6OH40cQ8ZcbxJ4q9XGpu7XoS1ZQ1m9rMIphYu32Vou4IVdWoPpUA==}
+  '@ckeditor/ckeditor5-horizontal-line@47.6.1':
+    resolution: {integrity: sha512-YTSpxdrp8NteaWARH89dA+qUWAf3agw/Q1dRQF+XdiF2kaSXRPQCXJruvmy490H+3xtwUZVs/hSlwX9gT77Skg==}
 
-  '@ckeditor/ckeditor5-export-pdf@47.6.0':
-    resolution: {integrity: sha512-VX54C7djWnQ5VcfKaVRB0pb/FqtlZjL6OeAGp99dBA/qs0HWontgQ7lVc+8me6zjdEZmF1BHtiULDDEwCvpsrg==}
+  '@ckeditor/ckeditor5-html-embed@47.6.1':
+    resolution: {integrity: sha512-z4iYN6Il/PqpOBm+7OYM1mpXLUCbA7cMjq3MGIAwGwRHNFq8BWq/1by3P8FiF4ozaUyj8YgXXyWoggBC2qQRig==}
 
-  '@ckeditor/ckeditor5-export-word@47.6.0':
-    resolution: {integrity: sha512-UbLsD5bcGrhz8F1PKsfBdogZNuDhbq5R72tk1ae+K/kcvPOxYhqpLiDzsOLBzXNBQ4TSGw5e6CWsocbdHpWfBA==}
+  '@ckeditor/ckeditor5-html-support@47.6.1':
+    resolution: {integrity: sha512-F25LY88VYx0gZTrrThmt+kqF2thrwg52ZCIQeRujMd3RIueYEAEn7ZJ0p5iArDvm9qQXtLzsaijEyZr2edstPA==}
 
-  '@ckeditor/ckeditor5-find-and-replace@47.2.0':
-    resolution: {integrity: sha512-34Uzpbxi+/eJx/0CR9/T92wDaw67KLaYcm39+RY4OUCxC9EywEFruIJEg/M/Xu4iTVjdVKbpQ3ovGBuciiL1vQ==}
+  '@ckeditor/ckeditor5-icons@47.6.1':
+    resolution: {integrity: sha512-OEk5hPdMpE5/Cb2lZFtJL2XyMwy/S8xQzuAk2b2P2bJx33rJgU3pk9RUrayxCSa3p+tKqibOzm5GcshLJ7s7Tg==}
 
-  '@ckeditor/ckeditor5-find-and-replace@47.6.0':
-    resolution: {integrity: sha512-S6E6zgO3T4A5rFC3Idr7DvhD2QEov2yIrWVbkIFTc0Q4fuvuNIxoke59fvc+SYd9BeDvQawP7a3RjMBTgvVRGA==}
+  '@ckeditor/ckeditor5-image@47.6.1':
+    resolution: {integrity: sha512-yy7b/7WQqN0c7/VC1Ng5svQU1btXWauBfQjFgVV3AzGa+nVeJ1ZIcV2fAkUa6mB+lCu+5ziv7b7ord22baJYzg==}
 
-  '@ckeditor/ckeditor5-font@47.2.0':
-    resolution: {integrity: sha512-X/AYeNHc3Hibd56OfPwOEdYRIGX3eWtGQ/qIAEVkS2xCEDPhM0fTHpLTEpDsMukw9NRAqmhnQHIp2amGaOwY8g==}
+  '@ckeditor/ckeditor5-import-word@47.6.1':
+    resolution: {integrity: sha512-RETw654yL9JxdE1pdhXLPL7b3UbNxO3B16rBPRM2gcfdUOnRUv6OzgsTICMedRWmRRmqhTqdgdQyVD7ReryyHg==}
 
-  '@ckeditor/ckeditor5-font@47.6.0':
-    resolution: {integrity: sha512-MZ9nUVCF+H+uYZeEy2FRlRys4kUFhuFcTJSaVNh6+obC8p9yrdRk9sSIKzH3VfJwmY9RWwEGg5udcyuQ4QT7KQ==}
+  '@ckeditor/ckeditor5-indent@47.6.1':
+    resolution: {integrity: sha512-SaokgxUJevRrYfu5PKEMvVrUliybmxpb3Cx/f/JtOnPbyJSFrt05+/mt3XsqsSB0g8LaHH2PXQfD4vncGzE6DQ==}
 
-  '@ckeditor/ckeditor5-footnotes@47.6.0':
-    resolution: {integrity: sha512-XzxR/KJJ1cO1mH24eJ96e4xVRZFxE/qJHfWH1v5cyHlhgf3TJfztqN2leZBR6BWyBGj+rQH8VYBvmJu0zzytTw==}
-
-  '@ckeditor/ckeditor5-format-painter@47.6.0':
-    resolution: {integrity: sha512-/ycXinrkmbjiRPzXSQ946MF9GQIUCv42QvvOAS6jiuLQMXbPCLC7seniF54AQoZylNLfcpwO72GTz2pNCfjmjw==}
-
-  '@ckeditor/ckeditor5-fullscreen@47.2.0':
-    resolution: {integrity: sha512-Kf//0eQIuslGNVSbNkHXBELn/jZT+OsTIeo8PulZEbVI5do0vB/52w0F40rhgk8EudlGTxEmMOi0x/jrdR0MHg==}
-
-  '@ckeditor/ckeditor5-fullscreen@47.6.0':
-    resolution: {integrity: sha512-M53UtSJ5jLNwt34iqllHeW2zT7HEpZwzSWX/TLn/3Q4d95m9+HAO4vBHDkuX+wd2KTl+8MYcrXYSCNWDqWzU/A==}
-
-  '@ckeditor/ckeditor5-heading@47.2.0':
-    resolution: {integrity: sha512-m1zSERVh7gdVXwLLYgcAsy7lkIOuadmA5YuwyPpR/g3oa0j1gcuNm5y/73MTOPflPUn0g0Y9DzocF2G1WY2NiQ==}
-
-  '@ckeditor/ckeditor5-heading@47.6.0':
-    resolution: {integrity: sha512-hduHYHzcY3j+K4e2O6A72ksH16I885zWjydwFOCGXnIPUTZAL9ZZLwRuhqDQ6jZ8uNPqiXcuRpZd1tFIXbKXOg==}
-
-  '@ckeditor/ckeditor5-highlight@47.2.0':
-    resolution: {integrity: sha512-Fp59HRybXJpJl/DtliMTjiVrIA95jmm0SptvXtIucD0hdP9ZX6TOFPTzrRl29LZGITNuYDulPqvNTpFoechRmQ==}
-
-  '@ckeditor/ckeditor5-highlight@47.6.0':
-    resolution: {integrity: sha512-YXZWN6nIyVBrVvsYXkusruYYenNb84g6GgWilA2PwQxuW6CwTJ7PeAM9KkA3+HQm/hwAme+/I74940FoyOXMnA==}
-
-  '@ckeditor/ckeditor5-horizontal-line@47.2.0':
-    resolution: {integrity: sha512-/DHVMhI9vNs/NI+NQBbUXdzsXHj9hGKihtNDmbV5UP3Hy7l32Gv8k9nJVnBlDbBbHI6Wpxjj6GUxAiLZ46mc1Q==}
-
-  '@ckeditor/ckeditor5-horizontal-line@47.6.0':
-    resolution: {integrity: sha512-m7LZ0wS5GHfmm1rWR1xSs5a8e/CTx79k7ahZdexLmyKmVoI8d/rahsD7oPsaFz6E+lHHhFtz+mmcOURlpI8SCQ==}
-
-  '@ckeditor/ckeditor5-html-embed@47.2.0':
-    resolution: {integrity: sha512-VhI789/KDKmQhz9nQqq64odOtLpwjJbPQ/Pf54J2d7AGDvbuNVkjAMVdj5xXXzb/nXdys6zM8lPQZfQGI/Ya8A==}
-
-  '@ckeditor/ckeditor5-html-embed@47.6.0':
-    resolution: {integrity: sha512-i8/7VoWcPLuJGkGbDJVQMd63SdTVERDMcah9EqbDFR6uxX+BnhUdPDKiZmcrsIJ93uq6aiK8p3uDmoiEomWp6w==}
-
-  '@ckeditor/ckeditor5-html-support@47.2.0':
-    resolution: {integrity: sha512-IwaFBdv0qQQXfnA1LHL2BVQoioNJa9T8NIKDq2OG3mXg02jJvhJl84QADJ0ro36igjKsyfttsl8lM1pf00XAhA==}
-
-  '@ckeditor/ckeditor5-html-support@47.6.0':
-    resolution: {integrity: sha512-bGIhD71IUYfdC87LVh3kLDlB6UuMSyBAOPpEsOr/7r8oANhHgUI10BaImZVid03e5Wn5x+S9Jc9v1T38+eRzAQ==}
-
-  '@ckeditor/ckeditor5-icons@47.2.0':
-    resolution: {integrity: sha512-9rxAWNQEjZBHyMBQ8XXwfa+ubPBzQntd+nkWBAGTK6ddqHZIaQLsiLrUAdR5tyKKK9tnTkwyx1jycGRspZnoxw==}
-
-  '@ckeditor/ckeditor5-icons@47.6.0':
-    resolution: {integrity: sha512-Flu9jiUG7BjVfSdIXnCx4IBshDh4G/Aw6JhnysKstA4RvAOypF7hVkuYw2tqNUdkG7YV9LbYlTlWitFvWEazkw==}
-
-  '@ckeditor/ckeditor5-image@47.2.0':
-    resolution: {integrity: sha512-XbXvRS++kFku0l7GABhsribmQTBC/SOAfimDNKjg5rayhAXCfovys7YmmU0eicydpo4//fAaa8zvDYc8uXWZGA==}
-
-  '@ckeditor/ckeditor5-image@47.6.0':
-    resolution: {integrity: sha512-7X5qtCvqTSc3hJcxe6qTZ2WVIW0Q81z4l4ehIpiNF/vg4FogsSXPyJ5xro2KrNILLIXJzMx20a7BFN2S2HcepQ==}
-
-  '@ckeditor/ckeditor5-import-word@47.6.0':
-    resolution: {integrity: sha512-IVewuKEjQfWX5wfl/eHKiVT7AnpyFGdkE6gGzZoDR7zjKV31s2XMNgbgMMv+H5p7CXejRNceze4Phx5tGiDk/Q==}
-
-  '@ckeditor/ckeditor5-indent@47.2.0':
-    resolution: {integrity: sha512-Q85+b+o+nonhJ/I9K9wB9XeZ5W8rS9k66VvoDHxL3jJ6g6C+oyEAOomooTDCvJvBgDN6vGpcwzznKp0Q8baoCQ==}
-
-  '@ckeditor/ckeditor5-indent@47.6.0':
-    resolution: {integrity: sha512-Rsnw5FHUGRlzyixRtgLeCrK2u3+d1+Bliq8hlQcMWvXB7wfD1GTDSsEU2MxGM7QtGuMbqFa+gO0hfzjEFgRv5g==}
-
-  '@ckeditor/ckeditor5-integrations-common@2.2.3':
-    resolution: {integrity: sha512-92kQWQj1wiABF7bY1+J79Ze+WHr7pwVBufn1eeJLWcTXbPQq4sAolfKv8Y8Ka9g69mdyE9+GPWmGFYDeQJVPDg==}
-    engines: {node: '>=18.0.0'}
+  '@ckeditor/ckeditor5-integrations-common@2.2.4':
+    resolution: {integrity: sha512-Qd6nTE6ldCZ8JyCVZWBRmBOqQnV/LlGHZqsnhxYv5IbXkJuUdskbsg+0VYDD1v9JEH2B0sTHLY3WYJHpijm2tg==}
     peerDependencies:
       ckeditor5: '>=42.0.0 || ^0.0.0-nightly'
 
-  '@ckeditor/ckeditor5-language@47.2.0':
-    resolution: {integrity: sha512-kc5MqQnvQtUPuvRJfdqXHQZNQyHVy/ZZv5laPY1AKrsKqc5SJO4y3v//4yHvdn45V4QKLwMOy4yC365Sdq0UpA==}
+  '@ckeditor/ckeditor5-language@47.6.1':
+    resolution: {integrity: sha512-YZpySDIa4Y40T9wwKIFsAlDujELkgUtoKw/+4Wl8BHlDnq/40VxXFbOSSXu4TnnVeqVFcnzTjp6Zv8CHtmY3yw==}
 
-  '@ckeditor/ckeditor5-language@47.6.0':
-    resolution: {integrity: sha512-nwV0HvQ7xhADG74TdsYZaB3rgiJMlXEqZ1rUQ+Lcl/IcYWCeyL8UaW6CwHzwlod2wTwaZhoIgfEMAk0f50b+qg==}
+  '@ckeditor/ckeditor5-line-height@47.6.1':
+    resolution: {integrity: sha512-oGhvlISZxq2pIOUzXvNwxbpzZiJH7A5rI17twEyLSxGWFNXkKRrnqJJng3GocTGfprqMXAgUA+4GDxFQ+hfSWQ==}
 
-  '@ckeditor/ckeditor5-line-height@47.6.0':
-    resolution: {integrity: sha512-j1zBum22qm9igfUceyEoOSELRlgpes6Zr3hcQVkrlObC5QuAXnNmEY3rpzRmptvSoIvAz8qobtIokydiSYrdyA==}
+  '@ckeditor/ckeditor5-link@47.6.1':
+    resolution: {integrity: sha512-A/gjF7e00R/ESUotqR08EeGM91V031DiHiGwYn7b+iZ1bejsdEu3yQK707bZ4U6ByEYBUOMtq1bOMYUtGJl6EA==}
 
-  '@ckeditor/ckeditor5-link@47.2.0':
-    resolution: {integrity: sha512-ijaF1Ic23FH9qulW2ZuaxecmdT0JuK/4XNkdaoRntloHiVZ/tFAu+o/6st/pDXfutDBmnEXwrNGVtzO/JTPhrw==}
+  '@ckeditor/ckeditor5-list-multi-level@47.6.1':
+    resolution: {integrity: sha512-vpf24tZf8Mdi/rUvsDqdLHkgLc6UiHqtp/Oe50yTjLM+hftewIyF6Vm18Qzc53MdtvNRWFwwZIVM4ZHorIT63Q==}
 
-  '@ckeditor/ckeditor5-link@47.6.0':
-    resolution: {integrity: sha512-YEw1y9nMqF3hYbrJ47DbeMGpyZj04uDf89tcYR5Ti27k3P4gqwCjBh/L/q+yiRmDXhfLbne7Zb4sqF6TVDBqog==}
+  '@ckeditor/ckeditor5-list@47.6.1':
+    resolution: {integrity: sha512-k7lXRJpZ8vkMQy0EWoYD8U6rQqYuKEbrTshlIjZSuBOQ9qlAb9llJ80OO0gteYZBOCMde1BJGjCeVxSNAI6eFA==}
 
-  '@ckeditor/ckeditor5-list-multi-level@47.6.0':
-    resolution: {integrity: sha512-Nr0lHJbOt+GwQ0wpbgTHtAylE4Hb9XWOfEA+xIH6TqZheLRKVmNNFirDMVjvIVfnh82zS1BX3L09l+eaIdSTUw==}
+  '@ckeditor/ckeditor5-markdown-gfm@47.6.1':
+    resolution: {integrity: sha512-bt4UsDKTmq5iyu5TkmxpC/Z5zZEsw8bcCr5egjgNtV5ozJF1E+54iQBjKIYNYIWRdD0PAEEGFE15QoWzSHBtxw==}
 
-  '@ckeditor/ckeditor5-list@47.2.0':
-    resolution: {integrity: sha512-PDjTQLn2CqrZ4XuAAJWY2vA5bkVu8UHKQZa1+ddfS4FbvfF2QR3eDX5axywpuaCb2Dm2ZQoqxpA5GQmt1fUehg==}
+  '@ckeditor/ckeditor5-media-embed@47.6.1':
+    resolution: {integrity: sha512-G18SeOxXVy+k0SQYHkw1HQtS6/PkqpX2Mv6zM7os9aG3OpPmX8tCqDK+X7TaMx3FRJlDV0ujOy5Qfs71SJrqKA==}
 
-  '@ckeditor/ckeditor5-list@47.6.0':
-    resolution: {integrity: sha512-LyvFrLKZS3DjNX/9J+uRJ/AvwesqD1/+BfeqGF3eP0XWhqJLI4rePosyOl3H91050zWlDuLFINo4lYGL0xDkAw==}
+  '@ckeditor/ckeditor5-mention@47.6.1':
+    resolution: {integrity: sha512-/53LFzYqcgvd8pL02XlNBduucfnakDVvY86vC02spDuTsUH5qUMqLaz2FHSo9AH2y3kNVp98KDnqI/QjNZCd+Q==}
 
-  '@ckeditor/ckeditor5-markdown-gfm@47.2.0':
-    resolution: {integrity: sha512-mt47/GMxrsAL3u/aBjOuH5ETSLH0knoYJpchYb7sXzIuQlY7xPqvcONyD9700TAN30FV7qpOVKUqI7tRyLL5uA==}
+  '@ckeditor/ckeditor5-merge-fields@47.6.1':
+    resolution: {integrity: sha512-vukSTLFSReqfEDPmJLjFsEJz5VKxTd3Wt8IHsazJ2ksmp9MUT2haN3hXkzdyVvJrrP1kRBSuiFfu+Vk8SrrG+w==}
 
-  '@ckeditor/ckeditor5-markdown-gfm@47.6.0':
-    resolution: {integrity: sha512-rgL51xVnVsXafj4OwyfjG4roZg6FXHMlcEsZsympauyehdl/IJeE9Jia8fuS7Joef7PJQNpadPr/5IE499e1Xg==}
+  '@ckeditor/ckeditor5-minimap@47.6.1':
+    resolution: {integrity: sha512-ksKOy4wxzs3pkhfzVtnnsu5rgJxqYHMKM7X8Rkhx9BSshcKFeuNIUVsSh+7QWDQStWKSZ/qAx+0rezdJCm6gvQ==}
 
-  '@ckeditor/ckeditor5-media-embed@47.2.0':
-    resolution: {integrity: sha512-lATTMej9pBsZk4qm8cOqLXhmrCq/t+HpP/zg3DWnYbiD6zclO69PSJxD09l9NsyOo0YZb8SYAsVISoKNaIOr0A==}
+  '@ckeditor/ckeditor5-operations-compressor@47.6.1':
+    resolution: {integrity: sha512-gnijLmjVP8VLiz97e5rGODgVqcpdXxUABs8eIBUtwyDAttQQ+f3rFxWxdT66fM6h+0cGNlLS7lJRBeJHG+NmQg==}
 
-  '@ckeditor/ckeditor5-media-embed@47.6.0':
-    resolution: {integrity: sha512-vKlNWEo8ICUzZXzpdo0ZA/rF6nzBglYI7EHRu1LSUAPeSA+gNoh8itXHRlox0wYQ1N5DT5f6Z6ZwxlK1pHQBQg==}
+  '@ckeditor/ckeditor5-page-break@47.6.1':
+    resolution: {integrity: sha512-KBE1tLsnyIsh0v+S6p0G+WglkvfWvKCkOESmap+gct5xwmOE0HEgRVp6xFFBfHYuGSjSISvgUU4ofdnhseZivA==}
 
-  '@ckeditor/ckeditor5-mention@47.2.0':
-    resolution: {integrity: sha512-ZPvVwEQxcCUI0SvJa28JUULww/SCXiiZpfnMtaneMxsIOqesAFxPqMXA9HkyLotikuK1sezu5XzgJ2S5gdqw3A==}
+  '@ckeditor/ckeditor5-pagination@47.6.1':
+    resolution: {integrity: sha512-Dxx8BcPh4E/NH7mN5mzTlNGs0mkVqeKXGGHILTmwaO9vULr5s7r8TiXacRQZixp+pjb4FAGllvSvcHV0D/sE0A==}
 
-  '@ckeditor/ckeditor5-mention@47.6.0':
-    resolution: {integrity: sha512-odLiEzED4fTDn5SkM+RS5Rus32ghJp6+hcSWZIHwTTQ0QRJOGab+euKyY/PqNVP0rPI2Mq+Lz5uXRO5mfarahg==}
+  '@ckeditor/ckeditor5-paragraph@47.6.1':
+    resolution: {integrity: sha512-6FXs94lSb6n7V7Puwp1c9BMyjycOfsAjdPRSVGTx1THqQBziQZHuZeU9LBxJZBA1mzoQOfmFaC3v+wb8odBgAQ==}
 
-  '@ckeditor/ckeditor5-merge-fields@47.6.0':
-    resolution: {integrity: sha512-5RARB1jDyU0Nxs67DJhfICx77agXkl89gtHXZt7HaE3JcAF6BUdyY+y17K+6a4Iz2HJebfaW6uAbBSXRjdsCXg==}
+  '@ckeditor/ckeditor5-paste-from-office-enhanced@47.6.1':
+    resolution: {integrity: sha512-k7DrfuyGjzTaS5N2drlhRZXGAkDZdjjF86OkyOy0EPS0y+FGNyrwf/O99WtD3ZG/2x+CxaN8sDygAhazNtyNFQ==}
 
-  '@ckeditor/ckeditor5-minimap@47.2.0':
-    resolution: {integrity: sha512-Th6HspywP3JeGBMRUmpAuIyFa8XtrpMiGdsjazlKcHaitT6bHBTzaTjaWVnOuVY3gBdFAKsalv2ZEk8vIPqkhg==}
+  '@ckeditor/ckeditor5-paste-from-office@47.6.1':
+    resolution: {integrity: sha512-Lt/V8/q59WuPURpwS9Z1UWUU1q5fF7YUbDAapWatzJlK9J/c969nRMG2aXm3z+BjXv3Kdu9qs4Oqngw0sJ0KiA==}
 
-  '@ckeditor/ckeditor5-minimap@47.6.0':
-    resolution: {integrity: sha512-4hdS2HpkoYsx8cVsMFntN1nsvS0xsA8pHGiJFUMMNqooy77qDMRlAeaprRth+rQqruVNldGAdlnIs7LfqXoJug==}
+  '@ckeditor/ckeditor5-real-time-collaboration@47.6.1':
+    resolution: {integrity: sha512-7UUbrUy3WeejQRMT7GKpHcHxz5nqiKhrjplQAIlp3wux9m20rWx7tCyLlGFu3nSFGSv2YclKx6rPH7qS/PUJtw==}
 
-  '@ckeditor/ckeditor5-operations-compressor@47.6.0':
-    resolution: {integrity: sha512-M5buPqy4Au2paALDtJaRSLYh9Iy2I9G6fOWJVZgsijWQjVoE8d6rFkHcg+N6B5o79YtCJ9JrhOs0j7KvRRWxoQ==}
+  '@ckeditor/ckeditor5-remove-format@47.6.1':
+    resolution: {integrity: sha512-2lQvT4+OVIFQs67yKh54exnT5UV1rPjEZX7MqyhZ3Dr0rzyEW7b9tpFz7bP/EUOSa2LpFktNoLFOSnIAZnQdyQ==}
 
-  '@ckeditor/ckeditor5-page-break@47.2.0':
-    resolution: {integrity: sha512-DosfUorg3wZ3a6yM/ymsJQ1E2Rbqi08RFOQ4oQLPPAi2VRdTLt0BiqQPFMKJmy2T2k5K4TLc7bs0s3E96aQyXg==}
+  '@ckeditor/ckeditor5-restricted-editing@47.6.1':
+    resolution: {integrity: sha512-ufWtexBPqBxJNNjjIw9XQe8Q+cnwLV4en6PTvdBX/zXHq87QdjpFk6NRSLCgDTpNmO2GiXnl+FsqUjGJF27zDQ==}
 
-  '@ckeditor/ckeditor5-page-break@47.6.0':
-    resolution: {integrity: sha512-XpWPVmbCtBJD1kOtBqV/LjsVByt94xlhgk9IXXW8QE/XOoNh5Yb2JE3MisHSZ0yM3kXauROM0SWT1FVMYXx2RQ==}
+  '@ckeditor/ckeditor5-revision-history@47.6.1':
+    resolution: {integrity: sha512-5uOXu/ZAdhESGUp7/jjX1kZIdbw0W9AfBMWSSsibgc0tL0CQXFvjNj5/25qiknI1t4qvEmnY/FnBPa8DS94GMw==}
 
-  '@ckeditor/ckeditor5-pagination@47.6.0':
-    resolution: {integrity: sha512-wW/LetZR/awxd4dsexlcm/gDDyRjOomIgzEiyTDdKsHyGXrQOaI1Vt0pJvVIv2kNZuKz/39y5HMDru902DVkCA==}
+  '@ckeditor/ckeditor5-select-all@47.6.1':
+    resolution: {integrity: sha512-NKhujjJ04UdM/pObi45+q6Em0fD6pQ1m+g5qLgTsTyoFUq2rFhMZqeRSPGEXlfuR5dImA7hP8uQtXNtt/GpZ7g==}
 
-  '@ckeditor/ckeditor5-paragraph@47.2.0':
-    resolution: {integrity: sha512-x6nqRQjlAcOhirOE9umNdK8WckWcz7JPVU7IlPTzlrVAYCq+wiz6rgpuh4COUHnee4c31fF21On+OVyqgu7JvQ==}
+  '@ckeditor/ckeditor5-show-blocks@47.6.1':
+    resolution: {integrity: sha512-9MdxI7TjccCOcbdlzX+SBjFvt8CsdxCgyoJxZ2NYut6QJAJ6WPjH0yVxckZXC3LSkqIPzrIOJxHc7e2n+oFFvA==}
 
-  '@ckeditor/ckeditor5-paragraph@47.6.0':
-    resolution: {integrity: sha512-CxSIn9OLg/7Ol/TpwL+vZxgwwksMvR2ESI2kcSp94R8q3W8du2yoYSdPw0RzQtDuHmdGFs8JuN6xLYEU37oLBw==}
+  '@ckeditor/ckeditor5-slash-command@47.6.1':
+    resolution: {integrity: sha512-BhkuMkRaehwOniGynP7Vb/f2FCJYfjF4XsfQrH1FbFPD1rCYUQFQQyz+iEKC2hEzBv55KcyEdQAlx94HREZllw==}
 
-  '@ckeditor/ckeditor5-paste-from-office-enhanced@47.6.0':
-    resolution: {integrity: sha512-UBceHMoMLv/AMtwZ3fMZmbAav6uULvykai7jFKu6HXwEQDmvlksFmeG3XGK9WjR5hAawaOSmb2J1CD7zFDE99A==}
+  '@ckeditor/ckeditor5-source-editing-enhanced@47.6.1':
+    resolution: {integrity: sha512-MOsnED0SamPgxRvlN5J8zPpa2JyTsuopjs5kBPObbIBkR0vkGCLjqrOVpP4JTZ884q8isbt9Ex52oA+2wqlWGg==}
 
-  '@ckeditor/ckeditor5-paste-from-office@47.2.0':
-    resolution: {integrity: sha512-DGGNGNhl25ub8dFBKJF4jfMBoSSbF5uKzFShMNIaAVAagV6kkDWR0HJWAir5CuFrElzWTkPd0ZC5RNL76yTbtg==}
+  '@ckeditor/ckeditor5-source-editing@47.6.1':
+    resolution: {integrity: sha512-/NeN6KvgdlvmBzOGH1Uxk26zGti8HvvmBbHLOCzFqfXZRLHB+47BG+GtzOa82t6YnLjK7pvR23opyAApRf6zIA==}
 
-  '@ckeditor/ckeditor5-paste-from-office@47.6.0':
-    resolution: {integrity: sha512-lS33vEq8l8MoxJe5aSC3Pem1pt+SAHI/zlf83twmBw/pb0nDjuB3HjkK+Y4Qbe5RQc/4llPJ/PN8VlR5QWyBcg==}
+  '@ckeditor/ckeditor5-special-characters@47.6.1':
+    resolution: {integrity: sha512-O+WRAaDh3m/i3lWF+MaB0G++nBusB/uaB+koN+gwqiIfDHpGJ9HKr+KXrMZZYb0MjiGV0J5gswuwL+YvzNZ6rg==}
 
-  '@ckeditor/ckeditor5-real-time-collaboration@47.6.0':
-    resolution: {integrity: sha512-HMvRGNRZcFMFvO8LNOJbFWfzceiZbrOrNWUohX3keUJt4Xj83mYf4dzhKqtPCXxB6fPCVoPomK8KCr9JKZGF6w==}
+  '@ckeditor/ckeditor5-style@47.6.1':
+    resolution: {integrity: sha512-WD9lzsgIk3sB+Ec/mpgbYIZXr8cRBOcDAjFndfjuSQMZRYM5kCMpIz0qpvjGp1Glz2bmeg7CwfuLDvbZSqZrfA==}
 
-  '@ckeditor/ckeditor5-remove-format@47.2.0':
-    resolution: {integrity: sha512-CRWs7Osok8k3Oi2N7RvA12ECxi47wIyrDTsJ3lJYo8zDIbZdOXlv5o+In+mbsZ7lzNKLhKMAgRcF/PrGWcAaUg==}
+  '@ckeditor/ckeditor5-table@47.6.1':
+    resolution: {integrity: sha512-zFJWnqL0PpdlSs8U1m5Mu/gcuoJfi0GSpDqr174dqXLtFcMfIsftVWVTbY5d4f+OKAp8LifxOg3CMvLD1YNSGA==}
 
-  '@ckeditor/ckeditor5-remove-format@47.6.0':
-    resolution: {integrity: sha512-9+ygu79dgcynGYnQ5xkBOOwRS4DseF1gkSG4fsOfgR+53yGaDfmHrHAX4DBOrirpFPVYxBWkrbFPMY+2Wcvo4g==}
+  '@ckeditor/ckeditor5-template@47.6.1':
+    resolution: {integrity: sha512-Wd8AjACu0YEny43ZUNmOMdUhZk8G43pA5FHOIS9I98sBXIQFnB1uklYl8mAod1GUViBDPYrgqQKuY1lPnntuLg==}
 
-  '@ckeditor/ckeditor5-restricted-editing@47.2.0':
-    resolution: {integrity: sha512-ziFgoZCHaHzzrLeQ6XIlrcEazoGF6IC2+qzxGnO1A1NKY/8WVLmokKFLmUgDMnPLrhvz5Qqldj0dSS2pKhj6QQ==}
+  '@ckeditor/ckeditor5-theme-lark@47.6.1':
+    resolution: {integrity: sha512-iaRFqt6ExGAAsOc4AfJNbMyY+jnh//gMzGendqklhQzkwV3RGzN6buRtV0Fps+pKXnpRcbqaVHWv0GOIOaG58Q==}
 
-  '@ckeditor/ckeditor5-restricted-editing@47.6.0':
-    resolution: {integrity: sha512-vZ0ITt/ozwwUVP57GhqK7Q82yeOd3s3YgjNmNu2EFpd1apR2pYkNTJ2urghUiutVWQwBYum/H1WMwUxdOKC2tw==}
+  '@ckeditor/ckeditor5-track-changes@47.6.1':
+    resolution: {integrity: sha512-hmTT7nRmwkdhis46Xlx+gQZ5WdZI3M6KeCTD14SCqcbOi0V6DlnH17RmdPBEvEPXiDZc9HczGEEhuTMfz9/ZTg==}
 
-  '@ckeditor/ckeditor5-revision-history@47.6.0':
-    resolution: {integrity: sha512-Gm6iQm7DzmjzDen52uRFqkzOW3ocIhql+vkllkSsmo+brTcr0sPv8l+74Np1Lbn0ZJ+bFcWOxjAVO27Bns24bw==}
+  '@ckeditor/ckeditor5-typing@47.6.1':
+    resolution: {integrity: sha512-yuMJCK6+KpYyXHxkBKRtVuOF1L42eyhUlCCq4sNFHjoJfD3q3gunmesoGIkdezMZR5RpqpGSfrOapEG9orOBTg==}
 
-  '@ckeditor/ckeditor5-select-all@47.2.0':
-    resolution: {integrity: sha512-4kswe9jmKp6y1hTwWfJBxF8XuX1pgZxraAlm+ugJLhjsus/vGBVXBFNN7kH+RoNxC6tf1ZXly69dGTG4P/nXrg==}
+  '@ckeditor/ckeditor5-ui@47.6.1':
+    resolution: {integrity: sha512-zBEfMSpR26rVPvc9X4KXxQd0wQG42EM+37VHdrfwJL47PFlqXTGlbsZ9BBjlElNM1mpViWSW9zpt5JdE6vtHCQ==}
 
-  '@ckeditor/ckeditor5-select-all@47.6.0':
-    resolution: {integrity: sha512-AT6/MSUivNd3x0hYYTb8oVGtAdJ5mNJBCwM8RvjkWmX5RhqGv5xVAHt26w13mH+GNGyhot3aKVrmPgTfY7Zmqg==}
+  '@ckeditor/ckeditor5-undo@47.6.1':
+    resolution: {integrity: sha512-kxckLxZHglOTv0yd7cROpZAgOQFR7uJEKy+ehGaPrPy5eMrIhUqHcDWHv4sLNJfNg1IgQrsqYNHeIaTzT38RvQ==}
 
-  '@ckeditor/ckeditor5-show-blocks@47.2.0':
-    resolution: {integrity: sha512-eIzvA5zQEWNGVXhkCTYVfw32tpsFEx4nTPAVpsFEv0hb1sAMaOv5fIoFmwcx/C8CmN9sBiZtuovXGM5i/pwoTQ==}
+  '@ckeditor/ckeditor5-upload@47.6.1':
+    resolution: {integrity: sha512-GFMKl6pct+r26EQ4K2D22xokyDQIoRYQZSZFoPl4L04FFPVRuG60pA1YSNtyi7Am+T1fR3qOVBHAuXsANyeL6g==}
 
-  '@ckeditor/ckeditor5-show-blocks@47.6.0':
-    resolution: {integrity: sha512-jh9zSrHzjKf8Wqy6Y71+0sjkoCIiLJM13aIseaNuSuxpTU9RvSxciZp2wjpixjsWg3g0iD91QV+XPrVoEkfjgw==}
+  '@ckeditor/ckeditor5-uploadcare@47.6.1':
+    resolution: {integrity: sha512-g1rb80qlqgHdg++0aZuuPK3ZO2VwmWZSuNlH97Xbepk41giwxi14vo0YApCumAiFq3g02yRpXQQZX7vdCTViTw==}
 
-  '@ckeditor/ckeditor5-slash-command@47.6.0':
-    resolution: {integrity: sha512-g4mFiobI8J9ZjYu1x7nQ2bZiXJQLM1Kv/cKPsV7R1+6oxsrOPGPcDHiIV6C78sqLIqsYumLLrru+v7CJqp+6tg==}
+  '@ckeditor/ckeditor5-utils@47.6.1':
+    resolution: {integrity: sha512-gJl5DikvPjMEsv9DZmEVv6GOZEjHQN3kgaxvaAYpfg4VcT1RENHw46BfvPN/zUHsYwZlh7DxG3+o7h3M8Pzj1w==}
 
-  '@ckeditor/ckeditor5-source-editing-enhanced@47.6.0':
-    resolution: {integrity: sha512-K6/7CJqBbsdXDORY7W4N+48YPSY62bCDeqg9rM1n94UpLnN79s06yM4ftJ6RPY3O7keHKTV+nwQt/I9ti73zHA==}
+  '@ckeditor/ckeditor5-watchdog@47.6.1':
+    resolution: {integrity: sha512-mHum5WRT5PKiL80UwNMXiw//s1486smeCO2sgYJKZGrqlz7cSSHDOc8iUi8Cn2YuHvTfjgRjgcZxn0u9uhr1Mw==}
 
-  '@ckeditor/ckeditor5-source-editing@47.2.0':
-    resolution: {integrity: sha512-B82fbUiTBWYR3XTfUk/30Hsk9PAmPkmraKNJKGDoch0NXduPz8ehpCwbnrJdIvm7pozbgB11RjWzq56VcBX2Qw==}
+  '@ckeditor/ckeditor5-widget@47.6.1':
+    resolution: {integrity: sha512-rURYZlY9w+qjumkQ+VQ1cO32JJbuxuGoWIPj2lTC3uFjn6kDzYB9KvNItOykBJM/V11R7sEEOWvpKlnsMmlnzg==}
 
-  '@ckeditor/ckeditor5-source-editing@47.6.0':
-    resolution: {integrity: sha512-3GD5xVrvl7ddifeF99pSPmekJhoFZmLizboBBIln6n/ZdHm4wXHCmF9ELvUSPJsxFiHASWtEVEMyHVKk6A3J8g==}
+  '@ckeditor/ckeditor5-word-count@47.6.1':
+    resolution: {integrity: sha512-q/8jRqtEFQ5SQEY8GsJBtatD7OdQT2f1o7KdKVDcZ4UZTQCo2hi9d2zvHEkQ7drA0LO+D3WJrHNEd+B6wk1slg==}
 
-  '@ckeditor/ckeditor5-special-characters@47.2.0':
-    resolution: {integrity: sha512-aH1E1SEMRUF6gMdqPuFeDZvZRCUNJ/n8RWwXHFicsJArYDGOiATxVZQZbwk50duAsWcxxj0uTSHGwFXBL9evyQ==}
-
-  '@ckeditor/ckeditor5-special-characters@47.6.0':
-    resolution: {integrity: sha512-QVkL19eOEJshIEBjBHU9XP/DXY2P1xgts7EAC4e+XRvfL/wZLzVdCZZaIC4ELdiZD1wYUGpbL+jiV/twGQxWmg==}
-
-  '@ckeditor/ckeditor5-style@47.2.0':
-    resolution: {integrity: sha512-XAIl8oNHpFxTRbGIE+2vpKLgrP3VnknUTyasvL/HeS3iUHKLDRlh9d3ghozhuUqQaF5rnkzUQEBv/fv+4u3Y7A==}
-
-  '@ckeditor/ckeditor5-style@47.6.0':
-    resolution: {integrity: sha512-kr2KsSXxwWwkcox85OP8FIIjhoNDhSUURErf/B7kMf28CZcsV8wNv9a0A0gMk0FQDstmtXjUEsRgdHWIzpr/IA==}
-
-  '@ckeditor/ckeditor5-table@47.2.0':
-    resolution: {integrity: sha512-zxNHpl4L7HsOLCYiKrbyyHoM2dMGetgP4eTjYyWfn9gf+ydVs7o+LJVN5bsWt3J4ToamCj5G7VHZUmqUcPbN6A==}
-
-  '@ckeditor/ckeditor5-table@47.6.0':
-    resolution: {integrity: sha512-JkyEJpm/WDr9U6eQ0a9wN5MUVAoqP0lk6KPnAGn64TCHAs36raeTgNEIeLbWs+1rYcl3N5IiEG+J3TNzlPpjNA==}
-
-  '@ckeditor/ckeditor5-template@47.6.0':
-    resolution: {integrity: sha512-+34l1qrQQ2gok5QFbux6Wuos3LG7ohnU6E28jzBmLgJdIW4kSqOeem98B3o2da4Xq31RAR/eFDpDt9IThPIgew==}
-
-  '@ckeditor/ckeditor5-theme-lark@47.2.0':
-    resolution: {integrity: sha512-5Guefuo+Nllq4FMaFnLJlU/fICy2IQYw3T+0PTYjFqd59xTx6suwjv2ou41HKPfJ1b6NCbmkbhuaC59lGIfBtQ==}
-
-  '@ckeditor/ckeditor5-theme-lark@47.6.0':
-    resolution: {integrity: sha512-zXZLMcTcR7dSeeybQ5qOnaAk/UicN7BzyRJEFVRKTXpKCloaMFv6YX3xneEpAdH39cY265FhfVSu/Vwvthdr0Q==}
-
-  '@ckeditor/ckeditor5-track-changes@47.6.0':
-    resolution: {integrity: sha512-vc8L+lLlgQeUJ1cjn4Ge4hg+aAfNrK3t4XojwVvRQNj0tEag1gWe/5SEgKopLsOW8nqgF+s50jLCQTM0VZ1xSQ==}
-
-  '@ckeditor/ckeditor5-typing@47.2.0':
-    resolution: {integrity: sha512-BDJLlaX9SHFUfZegOEW7ZeJ0o/TBgabINNxa3CwtGuGBLHUAQ3IAFJ0Cd6jHq12J2kRDwiXZzvvgMyCH7jeeUQ==}
-
-  '@ckeditor/ckeditor5-typing@47.6.0':
-    resolution: {integrity: sha512-7dZylw4YGpxM4yXOO/vT9itMfJlyzkRe1+S3eC34Thh7q4pOOYERQQHuMVi4x+bifMyhR3AgpY8OdJ58R3gLqg==}
-
-  '@ckeditor/ckeditor5-ui@47.2.0':
-    resolution: {integrity: sha512-/yd1/JmIqJybqBRZvk/QGzeY6DZlJvPtyEqq9Ay+U4bUftr2DOrfOikM62okepYRCCtMQ4nQk3c2eFmacfym2A==}
-
-  '@ckeditor/ckeditor5-ui@47.6.0':
-    resolution: {integrity: sha512-bwQyS0APV01GIRzUtp7MLn8lVK60WKRCCs1FNYnpT+oPULgF4XycXwEoARzctfCdhoda3aQulVReC/tZkUeZkw==}
-
-  '@ckeditor/ckeditor5-undo@47.2.0':
-    resolution: {integrity: sha512-smq5O3GdqJXB+9o54BTn/LyB52OHiW9ekzacOuMNxtuA/KBwHpdsPFMcGFGH04W9O0qUtSdt3fYC0i+SJjYAww==}
-
-  '@ckeditor/ckeditor5-undo@47.6.0':
-    resolution: {integrity: sha512-sUXZCd2ZvKEKKZTzAQWaIrJfUO7E22w6+4rnx3i5H9YyUBiJF53r/O4/HJGZxshTskZe2f9nHp5pHSbFSC8UlA==}
-
-  '@ckeditor/ckeditor5-upload@47.2.0':
-    resolution: {integrity: sha512-uE4FwVtmJ6UACDC9N+H6HHGhlpAF8Fk2QCF/iBboh4VqhlFbFjMbXCAbsWrDik6C/p9r4Iv+IEmbpjsRTD+9SQ==}
-
-  '@ckeditor/ckeditor5-upload@47.6.0':
-    resolution: {integrity: sha512-bCjMHRfQWImu/6bmvPbOjdb3Kl+mT52SX3XKp5kmnKPESQhdfrWqVSr8H8+QpJi+0GuSxVEE3GcawPNwK+NqEg==}
-
-  '@ckeditor/ckeditor5-uploadcare@47.6.0':
-    resolution: {integrity: sha512-c6wZIeMwSR6DOOXmGlqqaj5vONPnnYBLjwC6jqmVVDHLQ0xfEerI28heJ042LNBOiKf21r6L6xxDxTTAEtgIWQ==}
-
-  '@ckeditor/ckeditor5-utils@47.2.0':
-    resolution: {integrity: sha512-1b9SWtGuPZApm9065swh+fivxQMvuAsVXHuo26OGV2EnQK//w7kHsxKhVGJMzfHeuev5KvhJ2zdo8SUvePfBoA==}
-
-  '@ckeditor/ckeditor5-utils@47.6.0':
-    resolution: {integrity: sha512-+IWW2h6lGjXjLM6qlTHhB8xA7aR500KYQ7FteIn+5Aa5fT0ytyth8+AtmqpVJgXEtIK7GRCuexp1SFAcGntB/g==}
-
-  '@ckeditor/ckeditor5-watchdog@47.2.0':
-    resolution: {integrity: sha512-C1AT7OqLBkPCUm4pjJe4n64qj+5vvMdQb2+lLMSz0SMsBqmYFrVYMlZWW4LjpaYUAYEmvTPcyDoqukBKRWNrRQ==}
-
-  '@ckeditor/ckeditor5-watchdog@47.6.0':
-    resolution: {integrity: sha512-0oxx4Gxy5M7V3n4Iy7z6N10MzR/fwrOkFipaiisUbeMb0vHkprI4/i3i/I76iwLGYReSzu7E2Ha6+r9k5dtlfQ==}
-
-  '@ckeditor/ckeditor5-widget@47.2.0':
-    resolution: {integrity: sha512-1vhfdeVPNc6UtCPAC+aKDNIi0EDxpAJ7TudepJVLXnS752V5rnArjPrYBfH6dkpHYV920CuxxsoS1sSuVVMrkA==}
-
-  '@ckeditor/ckeditor5-widget@47.6.0':
-    resolution: {integrity: sha512-/HMwSHiupKVDSEDFgqzfhGEksXN83bM/VTE00e1d4lP4CpNx6HAIopajPHu4dMDFLnIPPqFbtwdTKX9S/ffH3Q==}
-
-  '@ckeditor/ckeditor5-word-count@47.2.0':
-    resolution: {integrity: sha512-1ouy59G1Qxf6hTRnW9tSL7Xjsx8kGfTJvrH9mZWGIpmNo0pIM6Ts96U/qgr5RB0LbhYtqhbDq87F9QjMcfYUjQ==}
-
-  '@ckeditor/ckeditor5-word-count@47.6.0':
-    resolution: {integrity: sha512-XDZSCXWsbbGzG4Cimbl9ArS3mKD7IllvQGYOHZgry80iqvI+V488G7baAlNV+adgdAdeCeaI0VZjdJSrQ8brUQ==}
-
-  '@codemirror/autocomplete@6.19.0':
-    resolution: {integrity: sha512-61Hfv3cF07XvUxNeC3E7jhG8XNi1Yom1G0lRC936oLnlF+jrbrv8rc/J98XlYzcsAoTVupfsf5fLej1aI8kyIg==}
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
 
   '@codemirror/commands@6.8.1':
     resolution: {integrity: sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==}
@@ -1590,26 +1391,26 @@ packages:
   '@codemirror/lang-html@6.4.11':
     resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
 
-  '@codemirror/lang-javascript@6.2.4':
-    resolution: {integrity: sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==}
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
 
   '@codemirror/lang-markdown@6.3.2':
     resolution: {integrity: sha512-c/5MYinGbFxYl4itE9q/rgN/sMTjOr8XL5OWnC+EaRMLfCbVUmmubTJfdgpfcSS2SCaT7b+Q+xi3l6CgoE+BsA==}
 
-  '@codemirror/language@6.11.3':
-    resolution: {integrity: sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==}
+  '@codemirror/language@6.12.2':
+    resolution: {integrity: sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==}
 
-  '@codemirror/lint@6.9.0':
-    resolution: {integrity: sha512-wZxW+9XDytH3SKvS8cQzMyQCaaazH8XL1EMHleHe00wVzsv7NBQKVW2yzEHrRhmM7ZOhVdItPbvlRBvMp9ej7A==}
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
 
-  '@codemirror/state@6.5.2':
-    resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
 
   '@codemirror/theme-one-dark@6.1.3':
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
 
-  '@codemirror/view@6.38.6':
-    resolution: {integrity: sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==}
+  '@codemirror/view@6.40.0':
+    resolution: {integrity: sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1627,8 +1428,8 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.0.0
 
-  '@cypress/request@3.0.9':
-    resolution: {integrity: sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==}
+  '@cypress/request@3.0.10':
+    resolution: {integrity: sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==}
     engines: {node: '>= 6'}
 
   '@cypress/xvfb@1.2.4':
@@ -1646,8 +1447,8 @@ packages:
     resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
     engines: {node: '>=18'}
 
-  '@esbuild/aix-ppc64@0.25.10':
-    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -1658,8 +1459,14 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.10':
-    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1670,8 +1477,14 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.10':
-    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -1682,8 +1495,14 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.10':
-    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1694,8 +1513,14 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.10':
-    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -1706,8 +1531,14 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.10':
-    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1718,8 +1549,14 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.10':
-    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -1730,8 +1567,14 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.10':
-    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1742,8 +1585,14 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.10':
-    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -1754,8 +1603,14 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.10':
-    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1766,8 +1621,14 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.10':
-    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -1778,8 +1639,14 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.10':
-    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1790,8 +1657,14 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.10':
-    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -1802,8 +1675,14 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.10':
-    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1814,8 +1693,14 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.10':
-    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -1826,8 +1711,14 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.10':
-    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1838,8 +1729,14 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.10':
-    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -1850,8 +1747,14 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.10':
-    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1862,8 +1765,14 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.10':
-    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -1874,8 +1783,14 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.10':
-    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1886,8 +1801,14 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.10':
-    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -1898,14 +1819,26 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.10':
-    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.10':
-    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1916,8 +1849,14 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.10':
-    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1928,8 +1867,14 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.10':
-    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -1940,8 +1885,14 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.10':
-    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1952,22 +1903,28 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.9.0':
-    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/regexpp@4.12.1':
-    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.21.1':
-    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.4.1':
-    resolution: {integrity: sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==}
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/core@0.14.0':
@@ -1978,16 +1935,16 @@ packages:
     resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@0.16.0':
-    resolution: {integrity: sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==}
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@3.3.1':
-    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.38.0':
-    resolution: {integrity: sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==}
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/markdown@6.6.0':
@@ -2002,9 +1959,13 @@ packages:
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.4.0':
-    resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@gar/promise-retry@1.0.2':
+    resolution: {integrity: sha512-Lm/ZLhDZcBECta3TmCQSngiQykFdfw+QtI1/GYMsZd4l3nG+P8WLB16XuS7WaBGLQ+9E+cOcWQsth9cayuGt8g==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
@@ -2019,8 +1980,8 @@ packages:
   '@hapi/pinpoint@2.0.1':
     resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
 
-  '@hapi/tlds@1.1.3':
-    resolution: {integrity: sha512-QIvUMB5VZ8HMLZF9A2oWr3AFM430QC8oGd0L35y2jHpuW6bIIca6x/xL7zUf4J7L9WJ3qjz+iJII8ncaeMbpSg==}
+  '@hapi/tlds@1.1.6':
+    resolution: {integrity: sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==}
     engines: {node: '>=14.0.0'}
 
   '@hapi/topo@6.0.2':
@@ -2042,12 +2003,12 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@inquirer/ansi@1.0.1':
-    resolution: {integrity: sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==}
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
 
-  '@inquirer/checkbox@4.3.0':
-    resolution: {integrity: sha512-5+Q3PKH35YsnoPTh75LucALdAxom6xh5D1oeY561x4cqBuH24ZFVyFREPe14xgnrtmGu3EEt1dIi60wRVSnGCw==}
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2055,8 +2016,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/confirm@5.1.19':
-    resolution: {integrity: sha512-wQNz9cfcxrtEnUyG5PndC8g3gZ7lGDBzmWiXZkX8ot3vfZ+/BLjR8EvyGX4YzQLeVqtAlY/YScZpW7CW8qMoDQ==}
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2073,8 +2034,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/core@10.3.0':
-    resolution: {integrity: sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==}
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2082,8 +2043,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/editor@4.2.21':
-    resolution: {integrity: sha512-MjtjOGjr0Kh4BciaFShYpZ1s9400idOdvQ5D7u7lE6VztPFoyLcVNE5dXBmEEIQq5zi4B9h2kU+q7AVBxJMAkQ==}
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2091,8 +2052,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/expand@4.0.21':
-    resolution: {integrity: sha512-+mScLhIcbPFmuvU3tAGBed78XvYHSvCl6dBiYMlzCLhpr0bzGzd8tfivMMeqND6XZiaZ1tgusbUHJEfc6YzOdA==}
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2100,8 +2061,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/external-editor@1.0.2':
-    resolution: {integrity: sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==}
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2109,21 +2070,12 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@1.0.14':
-    resolution: {integrity: sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==}
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
     engines: {node: '>=18'}
 
-  '@inquirer/input@4.2.5':
-    resolution: {integrity: sha512-7GoWev7P6s7t0oJbenH0eQ0ThNdDJbEAEtVt9vsrYZ9FulIokvd823yLyhQlWHJPGce1wzP53ttfdCZmonMHyA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/number@3.0.21':
-    resolution: {integrity: sha512-5QWs0KGaNMlhbdhOSCFfKsW+/dcAVC2g4wT/z2MCiZM47uLgatC5N20kpkDQf7dHx+XFct/MJvvNGy6aYJn4Pw==}
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2131,8 +2083,26 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/password@4.0.21':
-    resolution: {integrity: sha512-xxeW1V5SbNFNig2pLfetsDb0svWlKuhmr7MPJZMYuDnCTkpVBI+X/doudg4pznc1/U+yYmWFFOi4hNvGgUo7EA==}
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2149,8 +2119,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/prompts@7.9.0':
-    resolution: {integrity: sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==}
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2158,8 +2128,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/rawlist@4.1.9':
-    resolution: {integrity: sha512-AWpxB7MuJrRiSfTKGJ7Y68imYt8P9N3Gaa7ySdkFj1iWjr6WfbGAhdZvw/UnhFXTHITJzxGUI9k8IX7akAEBCg==}
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2167,17 +2137,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/search@3.2.0':
-    resolution: {integrity: sha512-a5SzB/qrXafDX1Z4AZW3CsVoiNxcIYCzYP7r9RzrfMpaLpB+yWi5U8BWagZyLmwR0pKbbL5umnGRd0RzGVI8bQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/select@4.4.0':
-    resolution: {integrity: sha512-kaC3FHsJZvVyIjYBs5Ih8y8Bj4P/QItQWrZW22WJax7zTN+ZPXVGuOM55vzbdCP9zKUiBd9iEJVdesujfF+cAA==}
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2189,8 +2150,8 @@ packages:
     resolution: {integrity: sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==}
     engines: {node: '>=18'}
 
-  '@inquirer/type@3.0.9':
-    resolution: {integrity: sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==}
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2213,9 +2174,6 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  '@jridgewell/remapping@2.3.5':
-    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
-
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -2235,8 +2193,20 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  '@jsonjoy.com/base64@17.67.0':
+    resolution: {integrity: sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   '@jsonjoy.com/buffers@1.2.1':
     resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/buffers@17.67.0':
+    resolution: {integrity: sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -2247,8 +2217,68 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  '@jsonjoy.com/codegen@17.67.0':
+    resolution: {integrity: sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-core@4.56.11':
+    resolution: {integrity: sha512-wThHjzUp01ImIjfCwhs+UnFkeGPFAymwLEkOtenHewaKe2pTP12p6r1UuwikA9NEvNf9Vlck92r8fb8n/MWM5w==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-fsa@4.56.11':
+    resolution: {integrity: sha512-ZYlF3XbMayyp97xEN8ZvYutU99PCHjM64mMZvnCseXkCJXJDVLAwlF8Q/7q/xiWQRsv3pQBj1WXHd9eEyYcaCQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-builtins@4.56.11':
+    resolution: {integrity: sha512-CNmt3a0zMCIhniFLXtzPWuUxXFU+U+2VyQiIrgt/rRVeEJNrMQUABaRbVxR0Ouw1LyR9RjaEkPM6nYpED+y43A==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-to-fsa@4.56.11':
+    resolution: {integrity: sha512-5OzGdvJDgZVo+xXWEYo72u81zpOWlxlbG4d4nL+hSiW+LKlua/dldNgPrpWxtvhgyntmdFQad2UTxFyGjJAGhA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-utils@4.56.11':
+    resolution: {integrity: sha512-JADOZFDA3wRfsuxkT0+MYc4F9hJO2PYDaY66kRTG6NqGX3+bqmKu66YFYAbII/tEmQWPZeHoClUB23rtQM9UPg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node@4.56.11':
+    resolution: {integrity: sha512-D65YrnP6wRuZyEWoSFnBJSr5zARVpVBGctnhie4rCsMuGXNzX7IHKaOt85/Aj7SSoG1N2+/xlNjWmkLvZ2H3Tg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-print@4.56.11':
+    resolution: {integrity: sha512-rnaKRgCRIn8JGTjxhS0JPE38YM3Pj/H7SW4/tglhIPbfKEkky7dpPayNKV2qy25SZSL15oFVgH/62dMZ/z7cyA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-snapshot@4.56.11':
+    resolution: {integrity: sha512-IIldPX+cIRQuUol9fQzSS3hqyECxVpYMJQMqdU3dCKZFRzEl1rkIkw4P6y7Oh493sI7YdxZlKr/yWdzEWZ1wGQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   '@jsonjoy.com/json-pack@1.21.0':
     resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@17.67.0':
+    resolution: {integrity: sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -2259,8 +2289,20 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  '@jsonjoy.com/json-pointer@17.67.0':
+    resolution: {integrity: sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   '@jsonjoy.com/util@1.9.0':
     resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@17.67.0':
+    resolution: {integrity: sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -2274,26 +2316,26 @@ packages:
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
 
-  '@lezer/common@1.2.3':
-    resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
+  '@lezer/common@1.5.1':
+    resolution: {integrity: sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==}
 
-  '@lezer/css@1.3.0':
-    resolution: {integrity: sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==}
+  '@lezer/css@1.3.1':
+    resolution: {integrity: sha512-PYAKeUVBo3HFThruRyp/iK91SwiZJnzXh8QzkQlwijB5y+N5iB28+iLk78o2zmKqqV0uolNhCwFqB8LA7b0Svg==}
 
-  '@lezer/highlight@1.2.1':
-    resolution: {integrity: sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==}
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
 
-  '@lezer/html@1.3.12':
-    resolution: {integrity: sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==}
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
 
   '@lezer/javascript@1.5.4':
     resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
 
-  '@lezer/lr@1.4.2':
-    resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
+  '@lezer/lr@1.4.8':
+    resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
 
-  '@lezer/markdown@1.4.3':
-    resolution: {integrity: sha512-kfw+2uMrQ/wy/+ONfrH83OkdFNM0ye5Xq96cLlaCy7h5UT9FO54DU4oRoIc0CSBh5NWmWuiIJA7NGLMJbQ+Oxg==}
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
 
   '@listr2/prompt-adapter-inquirer@2.0.18':
     resolution: {integrity: sha512-0hz44rAcrphyXcA8IS7EJ2SCoaBZD2u5goE8S/e+q/DL+dOGpqpcLidVOFeLG3VgML62SXmfRLAhWt0zL1oW4Q==}
@@ -2477,8 +2519,8 @@ packages:
     resolution: {integrity: sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==}
     engines: {node: '>= 10'}
 
-  '@ngtools/webpack@19.2.19':
-    resolution: {integrity: sha512-R9aeTrOBiRVl8I698JWPniUAAEpSvzc8SUGWSM5UXWMcHnWqd92cOnJJ1aXDGJZKXrbhMhCBx9Dglmcks5IDpg==}
+  '@ngtools/webpack@19.2.22':
+    resolution: {integrity: sha512-PI8oiQasmew4pGs6E496JP4aGQI6ICRn1bJpjJDTNBTzEdEnEM67nKl1pFFe5D+JCZGF9HF72N3usVCpUZX4YA==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
       '@angular/compiler-cli': ^19.0.0 || ^19.2.0-next.0
@@ -2509,12 +2551,16 @@ packages:
     resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  '@npmcli/fs@5.0.0':
+    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@npmcli/git@6.0.3':
     resolution: {integrity: sha512-GUYESQlxZRAdhs3UhbB6pVRNUELQOHXwK9ruDkwmCv2aZ5y0SApQzUJCg02p3A7Ue2J5hxvlk1YI53c00NmRyQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  '@npmcli/git@7.0.0':
-    resolution: {integrity: sha512-vnz7BVGtOctJAIHouCJdvWBhsTVSICMeUgZo2c7XAi5d5Rrl80S1H7oPym7K03cRuinK5Q6s2dw36+PgXQTcMA==}
+  '@npmcli/git@7.0.2':
+    resolution: {integrity: sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   '@npmcli/installed-package-contents@3.0.0':
@@ -2522,28 +2568,45 @@ packages:
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
+  '@npmcli/installed-package-contents@4.0.0':
+    resolution: {integrity: sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   '@npmcli/node-gyp@4.0.0':
     resolution: {integrity: sha512-+t5DZ6mO/QFh78PByMq1fGSAub/agLJZDRfJRMeOSNCt8s9YVlTjmGpIPwPhvXTGUIJk+WszlT0rQa1W33yzNA==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/node-gyp@5.0.0':
+    resolution: {integrity: sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@npmcli/package-json@6.2.0':
     resolution: {integrity: sha512-rCNLSB/JzNvot0SEyXqWZ7tX2B5dD2a1br2Dp0vSYVo5jh8Z0EZ7lS9TsZ1UtziddB1UfNUaMCc538/HztnJGA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  '@npmcli/package-json@7.0.1':
-    resolution: {integrity: sha512-956YUeI0YITbk2+KnirCkD19HLzES0habV+Els+dyZaVsaM6VGSiNwnRu6t3CZaqDLz4KXy2zx+0N/Zy6YjlAA==}
+  '@npmcli/package-json@7.0.5':
+    resolution: {integrity: sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   '@npmcli/promise-spawn@8.0.3':
     resolution: {integrity: sha512-Yb00SWaL4F8w+K8YGhQ55+xE4RUNdMHV43WZGsiTM92gS+lC0mGsn7I4hLug7pbao035S6bj3Y3w0cUNGLfmkg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  '@npmcli/promise-spawn@9.0.1':
+    resolution: {integrity: sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@npmcli/redact@3.2.2':
     resolution: {integrity: sha512-7VmYAmk4csGv08QzrDKScdzn11jHPFGyqJW39FyPgPuAp3zIaUmuCo1yxw9aGs+NEJuTGQ9Gwqpt93vtJubucg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  '@npmcli/run-script@10.0.0':
-    resolution: {integrity: sha512-vaQj4nccJbAslopIvd49pQH2NhUp7G9pY4byUtmwhe37ZZuubGrx0eB9hW2F37uVNRuDDK6byFGXF+7JCuMSZg==}
+  '@npmcli/redact@4.0.0':
+    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/run-script@10.0.4':
+    resolution: {integrity: sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   '@npmcli/run-script@9.1.0':
@@ -2554,23 +2617,23 @@ packages:
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
     engines: {node: '>= 20'}
 
-  '@octokit/core@7.0.5':
-    resolution: {integrity: sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==}
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
     engines: {node: '>= 20'}
 
-  '@octokit/endpoint@11.0.1':
-    resolution: {integrity: sha512-7P1dRAZxuWAOPI7kXfio88trNi/MegQ0IJD3vfgC3b+LZo1Qe6gRJc2v0mz2USWWJOKrB2h5spXCzGbw+fAdqA==}
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
     engines: {node: '>= 20'}
 
-  '@octokit/graphql@9.0.2':
-    resolution: {integrity: sha512-iz6KzZ7u95Fzy9Nt2L8cG88lGRMr/qy1Q36ih/XVzMIlPDMYwaNLE/ENhqmIzgPrlNWiYJkwmveEetvxAgFBJw==}
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
     engines: {node: '>= 20'}
 
-  '@octokit/openapi-types@26.0.0':
-    resolution: {integrity: sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA==}
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
 
-  '@octokit/plugin-paginate-rest@13.2.0':
-    resolution: {integrity: sha512-YuAlyjR8o5QoRSOvMHxSJzPtogkNMgeMv2mpccrvdUGeC3MKyfi/hS+KiFwyH/iRKIKyx+eIMsDjbt3p9r2GYA==}
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
     engines: {node: '>= 20'}
     peerDependencies:
       '@octokit/core': '>=6'
@@ -2581,113 +2644,113 @@ packages:
     peerDependencies:
       '@octokit/core': '>=6'
 
-  '@octokit/plugin-rest-endpoint-methods@16.1.0':
-    resolution: {integrity: sha512-nCsyiKoGRnhH5LkH8hJEZb9swpqOcsW+VXv1QoyUNQXJeVODG4+xM6UICEqyqe9XFr6LkL8BIiFCPev8zMDXPw==}
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
     engines: {node: '>= 20'}
     peerDependencies:
       '@octokit/core': '>=6'
 
-  '@octokit/request-error@7.0.1':
-    resolution: {integrity: sha512-CZpFwV4+1uBrxu7Cw8E5NCXDWFNf18MSY23TdxCBgjw1tXXHvTrZVsXlW8hgFTOLw8RQR1BBrMvYRtuyaijHMA==}
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
     engines: {node: '>= 20'}
 
-  '@octokit/request@10.0.5':
-    resolution: {integrity: sha512-TXnouHIYLtgDhKo+N6mXATnDBkV05VwbR0TtMWpgTHIoQdRQfCSzmy/LGqR1AbRMbijq/EckC/E3/ZNcU92NaQ==}
+  '@octokit/request@10.0.8':
+    resolution: {integrity: sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==}
     engines: {node: '>= 20'}
 
-  '@octokit/rest@22.0.0':
-    resolution: {integrity: sha512-z6tmTu9BTnw51jYGulxrlernpsQYXpui1RK21vmXn8yF5bp6iX16yfTtJYGK5Mh1qDkvDOmp2n8sRMcQmR8jiA==}
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
     engines: {node: '>= 20'}
 
-  '@octokit/types@15.0.0':
-    resolution: {integrity: sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==}
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@parcel/watcher-android-arm64@2.5.1':
-    resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [android]
 
-  '@parcel/watcher-darwin-arm64@2.5.1':
-    resolution: {integrity: sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==}
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@parcel/watcher-darwin-x64@2.5.1':
-    resolution: {integrity: sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==}
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@parcel/watcher-freebsd-x64@2.5.1':
-    resolution: {integrity: sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==}
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  '@parcel/watcher-linux-arm-glibc@2.5.1':
-    resolution: {integrity: sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==}
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@parcel/watcher-linux-arm-musl@2.5.1':
-    resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@parcel/watcher-linux-arm64-glibc@2.5.1':
-    resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@parcel/watcher-linux-arm64-musl@2.5.1':
-    resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@parcel/watcher-linux-x64-glibc@2.5.1':
-    resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@parcel/watcher-linux-x64-musl@2.5.1':
-    resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@parcel/watcher-win32-arm64@2.5.1':
-    resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@parcel/watcher-win32-ia32@2.5.1':
-    resolution: {integrity: sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==}
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
     engines: {node: '>= 10.0.0'}
     cpu: [ia32]
     os: [win32]
 
-  '@parcel/watcher-win32-x64@2.5.1':
-    resolution: {integrity: sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==}
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [win32]
 
-  '@parcel/watcher@2.5.1':
-    resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
@@ -2883,13 +2946,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/wasm-node@4.53.2':
-    resolution: {integrity: sha512-oPSy4fH0C66muvPr/HU13K8X9QFO74Em+JUegHUpEwD61M3lihIlfrLpilhrEiiReFOfG00Qyhf7NGFuwkX2yA==}
+  '@rollup/wasm-node@4.59.0':
+    resolution: {integrity: sha512-cKB/Pe05aJWQYw3UFS79Id+KVXdExBxWful0+CSl24z3ukwOgBSy6l39XZNwfm3vCh/fpUrAAs+T7PsJ6dC8NA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  '@schematics/angular@19.2.20':
-    resolution: {integrity: sha512-xDrYxZvk9dGA2eVqufqLYmVSMSXxVtv30pBHGGU/2xr4QzHzdmMHflk4It8eh4WMNLhn7kqnzMREwtNI3eW/Gw==}
+  '@schematics/angular@19.2.22':
+    resolution: {integrity: sha512-ZCyfDHD3dbU/PEr9M4EGGAWxQLlmITKJgJNAvNMLv8aiXkV31SiUCGwvnXh0dVPkufv+hPnqd+5ZpwAso6wkPw==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
   '@sigstore/bundle@3.1.0':
@@ -2904,8 +2967,8 @@ packages:
     resolution: {integrity: sha512-nYxaSb/MtlSI+JWcwTHQxyNmWeWrUXJJ/G4liLrGG7+tS4vAz6LF3xRXqLH6wPIVUoZQel2Fs4ddLx4NCpiIYg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  '@sigstore/core@3.0.0':
-    resolution: {integrity: sha512-NgbJ+aW9gQl/25+GIEGYcCyi8M+ng2/5X04BMuIgoDfgvp18vDcoNHOQjQsG9418HGNYRxG3vfEXaR1ayD37gg==}
+  '@sigstore/core@3.1.0':
+    resolution: {integrity: sha512-o5cw1QYhNQ9IroioJxpzexmPjfCe7gzafd2RY3qnMpxr4ZEja+Jad/U8sgFpaue6bOaF+z7RVkyKVV44FN+N8A==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   '@sigstore/protobuf-specs@0.4.3':
@@ -2920,196 +2983,160 @@ packages:
     resolution: {integrity: sha512-knzjmaOHOov1Ur7N/z4B1oPqZ0QX5geUfhrVaqVlu+hl0EAoL4o+l0MSULINcD5GCWe3Z0+YJO8ues6vFlW0Yw==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  '@sigstore/sign@4.0.1':
-    resolution: {integrity: sha512-KFNGy01gx9Y3IBPG/CergxR9RZpN43N+lt3EozEfeoyqm8vEiLxwRl3ZO5sPx3Obv1ix/p7FWOlPc2Jgwfp9PA==}
+  '@sigstore/sign@4.1.0':
+    resolution: {integrity: sha512-Vx1RmLxLGnSUqx/o5/VsCjkuN5L7y+vxEEwawvc7u+6WtX2W4GNa7b9HEjmcRWohw/d6BpATXmvOwc78m+Swdg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   '@sigstore/tuf@3.1.1':
     resolution: {integrity: sha512-eFFvlcBIoGwVkkwmTi/vEQFSva3xs5Ot3WmBcjgjVdiaoelBLQaQ/ZBfhlG0MnG0cmTYScPpk7eDdGDWUcFUmg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  '@sigstore/tuf@4.0.0':
-    resolution: {integrity: sha512-0QFuWDHOQmz7t66gfpfNO6aEjoFrdhkJaej/AOqb4kqWZVbPWFZifXZzkxyQBB1OwTbkhdT3LNpMFxwkTvf+2w==}
+  '@sigstore/tuf@4.0.1':
+    resolution: {integrity: sha512-OPZBg8y5Vc9yZjmWCHrlWPMBqW5yd8+wFNl+thMdtcWz3vjVSoJQutF8YkrzI0SLGnkuFof4HSsWUhXrf219Lw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   '@sigstore/verify@2.1.1':
     resolution: {integrity: sha512-hVJD77oT67aowHxwT4+M6PGOp+E2LtLdTK3+FC0lBO9T7sYwItDMXZ7Z07IDCvR1M717a4axbIWckrW67KMP/w==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  '@sigstore/verify@3.0.0':
-    resolution: {integrity: sha512-moXtHH33AobOhTZF8xcX1MpOFqdvfCk7v6+teJL8zymBiDXwEsQH6XG9HGx2VIxnJZNm4cNSzflTLDnQLmIdmw==}
+  '@sigstore/verify@3.1.0':
+    resolution: {integrity: sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@smithy/abort-controller@4.2.11':
-    resolution: {integrity: sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==}
+  '@smithy/abort-controller@4.2.12':
+    resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/config-resolver@4.4.10':
-    resolution: {integrity: sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==}
+  '@smithy/config-resolver@4.4.11':
+    resolution: {integrity: sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/config-resolver@4.4.6':
-    resolution: {integrity: sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==}
+  '@smithy/core@3.23.11':
+    resolution: {integrity: sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.23.9':
-    resolution: {integrity: sha512-1Vcut4LEL9HZsdpI0vFiRYIsaoPwZLjAxnVQDUMQK8beMS+EYPLDQCXtbzfxmM5GzSgjfe2Q9M7WaXwIMQllyQ==}
+  '@smithy/credential-provider-imds@4.2.12':
+    resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@4.2.11':
-    resolution: {integrity: sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==}
+  '@smithy/eventstream-codec@4.2.12':
+    resolution: {integrity: sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-codec@4.2.11':
-    resolution: {integrity: sha512-Sf39Ml0iVX+ba/bgMPxaXWAAFmHqYLTmbjAPfLPLY8CrYkRDEqZdUsKC1OwVMCdJXfAt0v4j49GIJ8DoSYAe6w==}
+  '@smithy/eventstream-serde-browser@4.2.12':
+    resolution: {integrity: sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-browser@4.2.11':
-    resolution: {integrity: sha512-3rEpo3G6f/nRS7fQDsZmxw/ius6rnlIpz4UX6FlALEzz8JoSxFmdBt0SZnthis+km7sQo6q5/3e+UJcuQivoXA==}
+  '@smithy/eventstream-serde-config-resolver@4.3.12':
+    resolution: {integrity: sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-config-resolver@4.3.11':
-    resolution: {integrity: sha512-XeNIA8tcP/GDWnnKkO7qEm/bg0B/bP9lvIXZBXcGZwZ+VYM8h8k9wuDvUODtdQ2Wcp2RcBkPTCSMmaniVHrMlA==}
+  '@smithy/eventstream-serde-node@4.2.12':
+    resolution: {integrity: sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-node@4.2.11':
-    resolution: {integrity: sha512-fzbCh18rscBDTQSCrsp1fGcclLNF//nJyhjldsEl/5wCYmgpHblv5JSppQAyQI24lClsFT0wV06N1Porn0IsEw==}
+  '@smithy/eventstream-serde-universal@4.2.12':
+    resolution: {integrity: sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-universal@4.2.11':
-    resolution: {integrity: sha512-MJ7HcI+jEkqoWT5vp+uoVaAjBrmxBtKhZTeynDRG/seEjJfqyg3SiqMMqyPnAMzmIfLaeJ/uiuSDP/l9AnMy/Q==}
+  '@smithy/fetch-http-handler@5.3.15':
+    resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/fetch-http-handler@5.3.13':
-    resolution: {integrity: sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==}
+  '@smithy/hash-node@4.2.12':
+    resolution: {integrity: sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/hash-node@4.2.11':
-    resolution: {integrity: sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/invalid-dependency@4.2.11':
-    resolution: {integrity: sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==}
+  '@smithy/invalid-dependency@4.2.12':
+    resolution: {integrity: sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/is-array-buffer@4.2.0':
-    resolution: {integrity: sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/is-array-buffer@4.2.2':
     resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-content-length@4.2.11':
-    resolution: {integrity: sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==}
+  '@smithy/middleware-content-length@4.2.12':
+    resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.4.23':
-    resolution: {integrity: sha512-UEFIejZy54T1EJn2aWJ45voB7RP2T+IRzUqocIdM6GFFa5ClZncakYJfcYnoXt3UsQrZZ9ZRauGm77l9UCbBLw==}
+  '@smithy/middleware-endpoint@4.4.25':
+    resolution: {integrity: sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@4.4.40':
-    resolution: {integrity: sha512-YhEMakG1Ae57FajERdHNZ4ShOPIY7DsgV+ZoAxo/5BT0KIe+f6DDU2rtIymNNFIj22NJfeeI6LWIifrwM0f+rA==}
+  '@smithy/middleware-retry@4.4.42':
+    resolution: {integrity: sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-serde@4.2.12':
-    resolution: {integrity: sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==}
+  '@smithy/middleware-serde@4.2.14':
+    resolution: {integrity: sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-stack@4.2.11':
-    resolution: {integrity: sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==}
+  '@smithy/middleware-stack@4.2.12':
+    resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-config-provider@4.3.11':
-    resolution: {integrity: sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==}
+  '@smithy/node-config-provider@4.3.12':
+    resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-config-provider@4.3.8':
-    resolution: {integrity: sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==}
+  '@smithy/node-http-handler@4.4.16':
+    resolution: {integrity: sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.4.14':
-    resolution: {integrity: sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==}
+  '@smithy/property-provider@4.2.12':
+    resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/property-provider@4.2.11':
-    resolution: {integrity: sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==}
+  '@smithy/protocol-http@5.3.12':
+    resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/property-provider@4.2.8':
-    resolution: {integrity: sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==}
+  '@smithy/querystring-builder@4.2.12':
+    resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/protocol-http@5.3.11':
-    resolution: {integrity: sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==}
+  '@smithy/querystring-parser@4.2.12':
+    resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-builder@4.2.11':
-    resolution: {integrity: sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==}
+  '@smithy/service-error-classification@4.2.12':
+    resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-parser@4.2.11':
-    resolution: {integrity: sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==}
+  '@smithy/shared-ini-file-loader@4.4.7':
+    resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/service-error-classification@4.2.11':
-    resolution: {integrity: sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==}
+  '@smithy/signature-v4@5.3.12':
+    resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/shared-ini-file-loader@4.4.3':
-    resolution: {integrity: sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==}
+  '@smithy/smithy-client@4.12.5':
+    resolution: {integrity: sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/shared-ini-file-loader@4.4.6':
-    resolution: {integrity: sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==}
+  '@smithy/types@4.13.1':
+    resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/signature-v4@5.3.11':
-    resolution: {integrity: sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/smithy-client@4.12.3':
-    resolution: {integrity: sha512-7k4UxjSpHmPN2AxVhvIazRSzFQjWnud3sOsXcFStzagww17j1cFQYqTSiQ8xuYK3vKLR1Ni8FzuT3VlKr3xCNw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.12.0':
-    resolution: {integrity: sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.13.0':
-    resolution: {integrity: sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/url-parser@4.2.11':
-    resolution: {integrity: sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-base64@4.3.0':
-    resolution: {integrity: sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==}
+  '@smithy/url-parser@4.2.12':
+    resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-base64@4.3.2':
     resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-body-length-browser@4.2.0':
-    resolution: {integrity: sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-body-length-browser@4.2.2':
     resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-node@4.2.1':
-    resolution: {integrity: sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-body-length-node@4.2.3':
@@ -3120,56 +3147,40 @@ packages:
     resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-buffer-from@4.2.0':
-    resolution: {integrity: sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-buffer-from@4.2.2':
     resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-config-provider@4.2.0':
-    resolution: {integrity: sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-config-provider@4.2.2':
     resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-browser@4.3.39':
-    resolution: {integrity: sha512-ui7/Ho/+VHqS7Km2wBw4/Ab4RktoiSshgcgpJzC4keFPs6tLJS4IQwbeahxQS3E/w98uq6E1mirCH/id9xIXeQ==}
+  '@smithy/util-defaults-mode-browser@4.3.41':
+    resolution: {integrity: sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-node@4.2.42':
-    resolution: {integrity: sha512-QDA84CWNe8Akpj15ofLO+1N3Rfg8qa2K5uX0y6HnOp4AnRYRgWrKx/xzbYNbVF9ZsyJUYOfcoaN3y93wA/QJ2A==}
+  '@smithy/util-defaults-mode-node@4.2.44':
+    resolution: {integrity: sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-endpoints@3.2.8':
-    resolution: {integrity: sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-endpoints@3.3.2':
-    resolution: {integrity: sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==}
+  '@smithy/util-endpoints@3.3.3':
+    resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-hex-encoding@4.2.2':
     resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-middleware@4.2.11':
-    resolution: {integrity: sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==}
+  '@smithy/util-middleware@4.2.12':
+    resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-middleware@4.2.8':
-    resolution: {integrity: sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==}
+  '@smithy/util-retry@4.2.12':
+    resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-retry@4.2.11':
-    resolution: {integrity: sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.5.17':
-    resolution: {integrity: sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==}
+  '@smithy/util-stream@4.5.19':
+    resolution: {integrity: sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.2':
@@ -3179,10 +3190,6 @@ packages:
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@4.2.0':
-    resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
-    engines: {node: '>=18.0.0'}
 
   '@smithy/util-utf8@4.2.2':
     resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
@@ -3195,8 +3202,8 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@stylistic/eslint-plugin@4.4.1':
     resolution: {integrity: sha512-CEigAk7eOLyHvdgmpZsKFwtiqS2wFwI1fn4j09IU9GmD4euFM4jEBAViWeCqaNLlbX2k2+A/Fq9cje4HQBXuJQ==}
@@ -3218,8 +3225,8 @@ packages:
     resolution: {integrity: sha512-UUYHISyhCU3ZgN8yaear3cGATHb3SMuKHsQ/nVbHXcmnBf+LzQ/cQfhNG+rfaSHgqGKNEm2cOCLVLELStUQ1JA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  '@tufjs/models@4.0.0':
-    resolution: {integrity: sha512-h5x5ga/hh82COe+GoD4+gKUeV4T3iaYOxqLt41GRKApinPI7DMidhCmNVTjKfhCWFJIGXaFJee07XczdT4jdZQ==}
+  '@tufjs/models@4.1.0':
+    resolution: {integrity: sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   '@types/body-parser@1.19.6':
@@ -3243,9 +3250,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/cors@2.8.19':
-    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
-
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -3261,14 +3265,11 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/express-serve-static-core@4.19.7':
-    resolution: {integrity: sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==}
+  '@types/express-serve-static-core@4.19.8':
+    resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
 
-  '@types/express-serve-static-core@5.1.0':
-    resolution: {integrity: sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==}
-
-  '@types/express@4.17.23':
-    resolution: {integrity: sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==}
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -3276,8 +3277,8 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
-  '@types/http-proxy@1.17.16':
-    resolution: {integrity: sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==}
+  '@types/http-proxy@1.17.17':
+    resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -3306,8 +3307,8 @@ packages:
   '@types/postcss-import@14.0.3':
     resolution: {integrity: sha512-raZhRVTf6Vw5+QbmQ7LOHSDML71A5rj4+EqDzAbrZPfxfoGzFxMHRCq16VlddGIZpHELw0BG4G0YE2ANkdZiIQ==}
 
-  '@types/qs@6.14.0':
-    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
@@ -3315,17 +3316,17 @@ packages:
   '@types/retry@0.12.2':
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
 
-  '@types/send@0.17.5':
-    resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
 
-  '@types/send@1.2.0':
-    resolution: {integrity: sha512-zBF6vZJn1IaMpg3xUF25VK3gd3l8zwE0ZLRX7dsQyQi+jp4E8mMDJNGDYnYse+bQhYwWERTxVwHpi3dMOq7RKQ==}
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
 
   '@types/serve-index@1.9.4':
     resolution: {integrity: sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==}
 
-  '@types/serve-static@1.15.9':
-    resolution: {integrity: sha512-dOTIuqpWLyl3BBXU3maNQsS4A3zuuoYRNIvYSxxhebPfXg2mzWQEPne/nlJ37yOse6uGgR386uTpdsx4D0QZWA==}
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   '@types/sinonjs__fake-timers@8.1.1':
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -3348,63 +3349,63 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.46.1':
-    resolution: {integrity: sha512-rUsLh8PXmBjdiPY+Emjz9NX2yHvhS11v0SR6xNJkm5GM1MO9ea/1GoDKlHHZGrOJclL/cZ2i/vRUYVtjRhrHVQ==}
+  '@typescript-eslint/eslint-plugin@8.57.0':
+    resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.46.1
-      eslint: ^8.57.0 || ^9.0.0
+      '@typescript-eslint/parser': ^8.57.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.46.1':
-    resolution: {integrity: sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==}
+  '@typescript-eslint/parser@8.57.0':
+    resolution: {integrity: sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/project-service@8.46.1':
-    resolution: {integrity: sha512-FOIaFVMHzRskXr5J4Jp8lFVV0gz5ngv3RHmn+E4HYxSJ3DgDzU7fVI1/M7Ijh1zf6S7HIoaIOtln1H5y8V+9Zg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/scope-manager@8.46.1':
-    resolution: {integrity: sha512-weL9Gg3/5F0pVQKiF8eOXFZp8emqWzZsOJuWRUNtHT+UNV2xSJegmpCNQHy37aEQIbToTq7RHKhWvOsmbM680A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.46.1':
-    resolution: {integrity: sha512-X88+J/CwFvlJB+mK09VFqx5FE4H5cXD+H/Bdza2aEWkSb8hnWIQorNcscRl4IEo1Cz9VI/+/r/jnGWkbWPx54g==}
+  '@typescript-eslint/project-service@8.57.0':
+    resolution: {integrity: sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/type-utils@8.46.1':
-    resolution: {integrity: sha512-+BlmiHIiqufBxkVnOtFwjah/vrkF4MtKKvpXrKSPLCkCtAp8H01/VV43sfqA98Od7nJpDcFnkwgyfQbOG0AMvw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/types@8.46.1':
-    resolution: {integrity: sha512-C+soprGBHwWBdkDpbaRC4paGBrkIXxVlNohadL5o0kfhsXqOC6GYH2S/Obmig+I0HTDl8wMaRySwrfrXVP8/pQ==}
+  '@typescript-eslint/scope-manager@8.57.0':
+    resolution: {integrity: sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/typescript-estree@8.46.1':
-    resolution: {integrity: sha512-uIifjT4s8cQKFQ8ZBXXyoUODtRoAd7F7+G8MKmtzj17+1UbdzFl52AzRyZRyKqPHhgzvXunnSckVu36flGy8cg==}
+  '@typescript-eslint/tsconfig-utils@8.57.0':
+    resolution: {integrity: sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.46.1':
-    resolution: {integrity: sha512-vkYUy6LdZS7q1v/Gxb2Zs7zziuXN0wxqsetJdeZdRe/f5dwJFglmuvZBfTUivCtjH725C1jWCDfpadadD95EDQ==}
+  '@typescript-eslint/type-utils@8.57.0':
+    resolution: {integrity: sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.46.1':
-    resolution: {integrity: sha512-ptkmIf2iDkNUjdeu2bQqhFPV1m6qTnFFjg7PPDjxKWaMaP0Z6I9l30Jr3g5QqbZGdw8YdYvLp+XnqnWWZOg/NA==}
+  '@typescript-eslint/types@8.57.0':
+    resolution: {integrity: sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.57.0':
+    resolution: {integrity: sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.57.0':
+    resolution: {integrity: sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.57.0':
+    resolution: {integrity: sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -3436,54 +3437,54 @@ packages:
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  '@vitest/browser-playwright@4.0.18':
-    resolution: {integrity: sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==}
+  '@vitest/browser-playwright@4.1.0':
+    resolution: {integrity: sha512-2RU7pZELY9/aVMLmABNy1HeZ4FX23FXGY1jRuHLHgWa2zaAE49aNW2GLzebW+BmbTZIKKyFF1QXvk7DEWViUCQ==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.0.18
+      vitest: 4.1.0
 
-  '@vitest/browser@4.0.18':
-    resolution: {integrity: sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng==}
+  '@vitest/browser@4.1.0':
+    resolution: {integrity: sha512-tG/iOrgbiHQks0ew7CdelUyNEHkv8NLrt+CqdTivIuoSnXvO7scWMn4Kqo78/UGY1NJ6Hv+vp8BvRnED/bjFdQ==}
     peerDependencies:
-      vitest: 4.0.18
+      vitest: 4.1.0
 
-  '@vitest/coverage-v8@4.0.18':
-    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+  '@vitest/coverage-v8@4.1.0':
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
     peerDependencies:
-      '@vitest/browser': 4.0.18
-      vitest: 4.0.18
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.0.18':
-    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
-  '@vitest/mocker@4.0.18':
-    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.18':
-    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
 
-  '@vitest/runner@4.0.18':
-    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
 
-  '@vitest/snapshot@4.0.18':
-    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
 
-  '@vitest/spy@4.0.18':
-    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
 
-  '@vitest/utils@4.0.18':
-    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -3568,6 +3569,10 @@ packages:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -3583,8 +3588,8 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -3640,8 +3645,8 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
-  ansi-escapes@7.2.0:
-    resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
   ansi-html-community@0.0.8:
@@ -3698,8 +3703,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@0.3.11:
-    resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -3728,15 +3733,21 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
-  babel-loader@10.0.0:
-    resolution: {integrity: sha512-z8jt+EdS61AMw22nSfoNJAZ0vrtmhPRVi6ghL3rCeRZI8cdNYFiV5xeV3HbE7rlZZNmGH8BVccwWt8/ED0QOHA==}
+  babel-loader@10.1.1:
+    resolution: {integrity: sha512-JwKSzk2kjIe7mgPK+/lyZ2QAaJcpahNAdM+hgR2HI8D0OJVkdj8Rl6J3kaLYki9pwF7P2iWnD8qVv80Lq1ABtg==}
     engines: {node: ^18.20.0 || ^20.10.0 || >=22.0.0}
     peerDependencies:
-      '@babel/core': ^7.12.0
+      '@babel/core': ^7.12.0 || ^8.0.0-beta.1
+      '@rspack/core': ^1.0.0 || ^2.0.0-0
       webpack: ^5.104.1
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
 
   babel-loader@9.2.1:
     resolution: {integrity: sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==}
@@ -3745,8 +3756,8 @@ packages:
       '@babel/core': ^7.12.0
       webpack: ^5.104.1
 
-  babel-plugin-polyfill-corejs2@0.4.14:
-    resolution: {integrity: sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==}
+  babel-plugin-polyfill-corejs2@0.4.16:
+    resolution: {integrity: sha512-xaVwwSfebXf0ooE11BJovZYKhFjIvQo7TsyVpETuIeH2JHv0k/T6Y5j22pPTvqYqmpkxdlPAJlyJ0tfOJAoMxw==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
@@ -3755,8 +3766,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
-  babel-plugin-polyfill-regenerator@0.6.5:
-    resolution: {integrity: sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==}
+  babel-plugin-polyfill-regenerator@0.6.7:
+    resolution: {integrity: sha512-OTYbUlSwXhNgr4g6efMZgsO8//jA61P7ZbRX3iTT53VON8l+WQS8IAUEVo4a4cWknrg2W8Cj4gQhRYNCJ8GkAA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
@@ -3773,12 +3784,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  base64id@2.0.0:
-    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
-    engines: {node: ^4.5.0 || >= 5.9}
-
-  baseline-browser-mapping@2.9.19:
-    resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
+  baseline-browser-mapping@2.10.7:
+    resolution: {integrity: sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   batch@0.6.1:
@@ -3813,10 +3821,6 @@ packages:
   blurhash@2.0.5:
     resolution: {integrity: sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==}
 
-  body-parser@1.20.3:
-    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -3827,14 +3831,17 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  bowser@2.12.1:
-    resolution: {integrity: sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==}
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@5.0.3:
-    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3843,11 +3850,6 @@ packages:
 
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
-
-  browserslist@4.26.3:
-    resolution: {integrity: sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -3875,8 +3877,8 @@ packages:
     resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  cacache@20.0.1:
-    resolution: {integrity: sha512-+7LYcYGBYoNqTp1Rv7Ny1YjUo5E0/ftkQtraH3vkfAGgVHc+ouWdC8okAwQgQR7EVIdW6JTzTmhKFwzb+4okAQ==}
+  cacache@20.0.3:
+    resolution: {integrity: sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   cachedir@2.4.0:
@@ -3906,11 +3908,8 @@ packages:
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
-  caniuse-lite@1.0.30001750:
-    resolution: {integrity: sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==}
-
-  caniuse-lite@1.0.30001774:
-    resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
+  caniuse-lite@1.0.30001778:
+    resolution: {integrity: sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==}
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
@@ -3918,8 +3917,8 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  chai@6.2.1:
-    resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@4.1.2:
@@ -3935,8 +3934,8 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
-  chardet@2.1.0:
-    resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
   check-more-types@2.24.0:
     resolution: {integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==}
@@ -3958,23 +3957,20 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
-  ci-info@4.3.1:
-    resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
-  ckeditor5-collaboration@47.6.0:
-    resolution: {integrity: sha512-oDfOTzpEG6NRbP6a2qeHlmtdRSV+Ro03ZLKh8DiBKX9V+DILZato6x95jRNGynGIXmGTimpd7PvAPPswX4gd0g==}
+  ckeditor5-collaboration@47.6.1:
+    resolution: {integrity: sha512-OcwkLYmF1mmdhL4sQ+5OcmrsDvM27R8UZjnteNTc/LYmvmXAr6j8M/Zpbub4ugQXxaxcfJ6vAUwm9Wi9q9fk2Q==}
 
-  ckeditor5-premium-features@47.6.0:
-    resolution: {integrity: sha512-01OY5CEOPlAmd6rP2EEpAxWEf12bbMN6sa1klkwx2cAPQYDA1ES10wW/AuzaPEeE9cJ7kM1Sqb9cg/Jmlm/a0g==}
+  ckeditor5-premium-features@47.6.1:
+    resolution: {integrity: sha512-BsDE5Y6xX0oOc5SLCXLFEtNsKZj4xY2E8T2i1hQKtwrR66+cworvKKQSGnVz0RMDde407FbJrFdwkHVRJSPiAQ==}
     peerDependencies:
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.1
 
-  ckeditor5@47.2.0:
-    resolution: {integrity: sha512-mrG9UdpT4JC0I44vK1DV5UwfGhruEG/FMXIWwGv+LWYrKt4aLL/5NyNpW86UDO9YAFSaw6IdEcbJGC/WkMJJjA==}
-
-  ckeditor5@47.6.0:
-    resolution: {integrity: sha512-OynbpuohqK5XV+d5itPRMnXrFjbrTcJQp8xwFbeZzvD58aeoxVSLnM8hX2V6o3wM6OvkBdSGuKq+XhjKcRfM9g==}
+  ckeditor5@47.6.1:
+    resolution: {integrity: sha512-Za7+Dyju3RgfH4TF+zam7lvfOSr+Rd+0tABfR16HEtsARRPEmNBHYgS5nM3PZtNK4+ScliL6Ch3GFk7cd/TiOw==}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -3996,8 +3992,8 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
-  cli-spinners@3.3.0:
-    resolution: {integrity: sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ==}
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
 
   cli-table3@0.6.5:
@@ -4015,9 +4011,6 @@ packages:
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
-
-  cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -4045,8 +4038,8 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  color-name@2.0.2:
-    resolution: {integrity: sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==}
+  color-name@2.1.0:
+    resolution: {integrity: sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==}
     engines: {node: '>=12.20'}
 
   color-parse@2.0.2:
@@ -4113,10 +4106,6 @@ packages:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
     engines: {node: '>=0.8'}
 
-  connect@3.7.0:
-    resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
-    engines: {node: '>= 0.10.0'}
-
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
@@ -4131,12 +4120,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie-signature@1.0.6:
-    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
-
-  cookie@0.7.1:
-    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
-    engines: {node: '>= 0.6'}
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -4145,17 +4130,21 @@ packages:
   copy-anything@2.0.6:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
 
+  copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
+
   copy-webpack-plugin@12.0.2:
     resolution: {integrity: sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       webpack: ^5.104.1
 
-  core-js-compat@3.46.0:
-    resolution: {integrity: sha512-p9hObIIEENxSV8xIu+V68JjSeARg6UVMG5mR+JEUguG3sI6MsiS1njz2jHmyJDvA+8jX/sytkBHup6kxhM9law==}
+  core-js-compat@3.48.0:
+    resolution: {integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==}
 
-  core-js@3.46.0:
-    resolution: {integrity: sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==}
+  core-js@3.48.0:
+    resolution: {integrity: sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==}
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
@@ -4163,16 +4152,12 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  cors@2.8.6:
-    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
-    engines: {node: '>= 0.10'}
-
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
 
-  cosmiconfig@9.0.0:
-    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -4190,8 +4175,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-declaration-sorter@7.3.0:
-    resolution: {integrity: sha512-LQF6N/3vkAMYF4xoHLJfG718HRJh34Z8BnNhd6bosOMIVjMlhuZK5++oZa3uYAgrI5+7x2o27gUqTR2U/KjUOQ==}
+  css-declaration-sorter@7.3.1:
+    resolution: {integrity: sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
@@ -4214,6 +4199,18 @@ packages:
       webpack:
         optional: true
 
+  css-loader@7.1.4:
+    resolution: {integrity: sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
+      webpack: ^5.104.1
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
+
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
@@ -4221,8 +4218,8 @@ packages:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
-  css-tree@3.1.0:
-    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-what@6.2.2:
@@ -4234,8 +4231,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  cssnano-preset-default@7.0.9:
-    resolution: {integrity: sha512-tCD6AAFgYBOVpMBX41KjbvRh9c2uUjLXRyV7KHSIrwHiq5Z9o0TFfUCoM3TwVrRsRteN3sVXGNvjVNxYzkpTsA==}
+  cssnano-preset-default@7.0.11:
+    resolution: {integrity: sha512-waWlAMuCakP7//UCY+JPrQS1z0OSLeOXk2sKWJximKWGupVxre50bzPlvpbUwZIDylhf/ptf0Pk+Yf7C+hoa3g==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
@@ -4246,8 +4243,8 @@ packages:
     peerDependencies:
       postcss: ^8.4.32
 
-  cssnano@7.1.1:
-    resolution: {integrity: sha512-fm4D8ti0dQmFPeF8DXSAA//btEmqCOgAc/9Oa3C1LW94h5usNrJEfrON7b4FkPZgnDEn6OUs5NdxiJZmAtGOpQ==}
+  cssnano@7.1.3:
+    resolution: {integrity: sha512-mLFHQAzyapMVFLiJIn7Ef4C2UCEvtlTlbyILR6B5ZsUAV3D/Pa761R5uC1YPhyBkRd3eqaDm2ncaNrD7R4mTRg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
@@ -4255,9 +4252,6 @@ packages:
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
-
-  custom-event@1.0.1:
-    resolution: {integrity: sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==}
 
   cypress@13.17.0:
     resolution: {integrity: sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==}
@@ -4271,12 +4265,8 @@ packages:
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
-  date-format@4.0.14:
-    resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
-    engines: {node: '>=4.0'}
-
-  dayjs@1.11.18:
-    resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -4316,8 +4306,8 @@ packages:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
 
-  decode-named-character-reference@1.2.0:
-    resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
@@ -4329,8 +4319,8 @@ packages:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
     engines: {node: '>=18'}
 
-  default-browser@5.4.0:
-    resolution: {integrity: sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==}
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
 
   defaults@1.0.4:
@@ -4364,11 +4354,6 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  detect-libc@1.0.3:
-    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
-    engines: {node: '>=0.10'}
-    hasBin: true
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -4378,9 +4363,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  di@0.0.1:
-    resolution: {integrity: sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==}
 
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
@@ -4393,9 +4375,6 @@ packages:
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
-
-  dom-serialize@2.2.1:
-    resolution: {integrity: sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -4426,11 +4405,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.235:
-    resolution: {integrity: sha512-i/7ntLFwOdoHY7sgjlTIDo4Sl8EdoTjWIaKinYOVfC6bOp71bmwenyZthWHcasxgHDNWbWxvG9M3Ia116zIaYQ==}
-
-  electron-to-chromium@1.5.302:
-    resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
+  electron-to-chromium@1.5.313:
+    resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -4444,10 +4420,6 @@ packages:
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
-
-  encodeurl@1.0.2:
-    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
-    engines: {node: '>= 0.8'}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -4466,25 +4438,13 @@ packages:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
 
-  engine.io@6.6.5:
-    resolution: {integrity: sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==}
-    engines: {node: '>=10.2.0'}
-
-  enhanced-resolve@5.18.3:
-    resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
-    engines: {node: '>=10.13.0'}
-
-  enhanced-resolve@5.19.0:
-    resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
+  enhanced-resolve@5.20.0:
+    resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
-
-  ent@2.2.2:
-    resolution: {integrity: sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==}
-    engines: {node: '>= 0.4'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -4494,12 +4454,16 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
-  envinfo@7.18.0:
-    resolution: {integrity: sha512-02QGCLRW+Jb8PC270ic02lat+N57iBaWsvHjcJViqp6UVupRB+Vsg7brYPTqEFXvsdTql3KnSczv5ModZFpl8Q==}
+  envinfo@7.21.0:
+    resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
     engines: {node: '>=4'}
     hasBin: true
 
@@ -4525,9 +4489,6 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
-
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -4542,8 +4503,8 @@ packages:
   es-toolkit@1.39.5:
     resolution: {integrity: sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==}
 
-  esbuild-loader@4.4.0:
-    resolution: {integrity: sha512-4J+hXTpTtEdzUNLoY8ReqDNJx2NoldfiljRCiKbeYUuZmVaiJeDqFgyAzz8uOopaekwRoCcqBFyEroGQLFVZ1g==}
+  esbuild-loader@4.4.2:
+    resolution: {integrity: sha512-8LdoT9sC7fzfvhxhsIAiWhzLJr9yT3ggmckXxsgvM07wgrRxhuT98XhLn3E7VczU5W5AFsPKv9DdWcZIubbWkQ==}
     peerDependencies:
       webpack: ^5.104.1
 
@@ -4552,13 +4513,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.25.10:
-    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.25.4:
     resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4581,15 +4547,15 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-config-ckeditor5@13.0.0:
-    resolution: {integrity: sha512-kJfQ+UJBWrBKGEmfkWlqP6RSEeIn7ursIzZx1E0F/J7fdz0ItKFIKZXZxxqETDQAWnZWKmzj5tx1wbnMkRBFlw==}
+  eslint-config-ckeditor5@13.0.1:
+    resolution: {integrity: sha512-UbB3v+OhG6tVSp9hi21WkU9mTTtUj/1GQFqHDgEm0YdKEKxhtCkIyPlt4b8UR53bXbRb1E+gcGNVBvYUPqytAw==}
     engines: {node: '>=24.11.0'}
     peerDependencies:
       eslint: ^9.0.0
       typescript: ^5.0.0
 
-  eslint-plugin-ckeditor5-rules@13.0.0:
-    resolution: {integrity: sha512-flXURsHYkTlPIHWlxt6BB40DRkdl8l1+qp9rFEi5ruF9ZW6hPRPN3Z4fvalrUAy/JuxmmwrcYKpiv+5keOHuPw==}
+  eslint-plugin-ckeditor5-rules@13.0.1:
+    resolution: {integrity: sha512-T3DsRDZWp0NV1i7Tp7usvSgUm0QmJjQrq8RzxKdR5ezaesIkIP6yS3x/bAB+vvKPY+UY1a3id2lk3/eUmS02Dw==}
     engines: {node: '>=24.11.0'}
 
   eslint-plugin-mocha@11.2.0:
@@ -4613,8 +4579,12 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.38.0:
-    resolution: {integrity: sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==}
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -4632,8 +4602,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  esquery@1.6.0:
-    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
@@ -4671,8 +4641,8 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
-  eventemitter3@5.0.1:
-    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -4694,15 +4664,15 @@ packages:
     resolution: {integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==}
     engines: {node: '>=4'}
 
-  expect-type@1.2.2:
-    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
-  express@4.21.2:
-    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
   extend-shallow@2.0.1:
@@ -4740,8 +4710,8 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.0.0:
-    resolution: {integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==}
+  fast-xml-builder@1.1.3:
+    resolution: {integrity: sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==}
 
   fast-xml-parser@5.4.1:
     resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
@@ -4751,8 +4721,8 @@ packages:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
 
-  fastq@1.19.1:
-    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
@@ -4785,12 +4755,8 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  finalhandler@1.1.2:
-    resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
-    engines: {node: '>= 0.8'}
-
-  finalhandler@1.3.1:
-    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
   find-cache-dir@3.3.2:
@@ -4821,8 +4787,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -4839,10 +4805,6 @@ packages:
 
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
-
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
-    engines: {node: '>= 6'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -4870,10 +4832,6 @@ packages:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
 
-  fs-extra@8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
-
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
@@ -4881,9 +4839,6 @@ packages:
   fs-minipass@3.0.3:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -4909,8 +4864,8 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.4.0:
-    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
@@ -4932,8 +4887,8 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  get-tsconfig@4.12.0:
-    resolution: {integrity: sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==}
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
   getos@3.2.1:
     resolution: {integrity: sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==}
@@ -4966,19 +4921,9 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@11.1.0:
-    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
-    engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
-  glob@13.0.0:
-    resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
-    engines: {node: 20 || >=22}
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -4992,8 +4937,8 @@ packages:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
-  globals@16.4.0:
-    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
+  globals@16.5.0:
+    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
 
   globby@14.1.0:
@@ -5006,9 +4951,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
@@ -5099,19 +5041,18 @@ packages:
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
   http-deceiver@1.2.7:
     resolution: {integrity: sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==}
 
-  http-errors@1.6.3:
-    resolution: {integrity: sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==}
+  http-errors@1.8.1:
+    resolution: {integrity: sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==}
     engines: {node: '>= 0.6'}
-
-  http-errors@2.0.0:
-    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
-    engines: {node: '>= 0.8'}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -5174,8 +5115,8 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  iconv-lite@0.7.0:
-    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   icss-utils@5.1.0:
@@ -5208,8 +5149,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  immutable@5.1.4:
-    resolution: {integrity: sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==}
+  immutable@5.1.5:
+    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -5228,13 +5169,6 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
-  inherits@2.0.3:
-    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -5246,11 +5180,15 @@ packages:
     resolution: {integrity: sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  injection-js@2.5.0:
-    resolution: {integrity: sha512-UpY2ONt4xbht4GhSqQ2zMJ1rBIQq4uOY+DlR6aOeYyqK7xadXt7UQbJIyxmgk288bPMkIZKjViieHm0O0i72Jw==}
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
-  inquirer@12.10.0:
-    resolution: {integrity: sha512-K/epfEnDBZj2Q3NMDcgXWZye3nhSPeoJnOh8lcKWrldw54UEZfS4EmAMsAsmVbl7qKi+vjAsy39Sz4fbgRMewg==}
+  injection-js@2.6.1:
+    resolution: {integrity: sha512-dbR5bdhi7TWDoCye9cByZqeg/gAfamm8Vu3G1KZOTYkOif8WkuM8CD0oeDPtZYMzT5YH76JAFB7bkmyY9OJi2A==}
+
+  inquirer@12.11.1:
+    resolution: {integrity: sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -5262,16 +5200,16 @@ packages:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
 
-  ip-address@10.0.1:
-    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
-  ipaddr.js@2.2.0:
-    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
 
   is-arrayish@0.2.1:
@@ -5331,8 +5269,8 @@ packages:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
-  is-network-error@1.3.0:
-    resolution: {integrity: sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==}
+  is-network-error@1.3.1:
+    resolution: {integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==}
     engines: {node: '>=16'}
 
   is-number@7.0.0:
@@ -5367,10 +5305,6 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
-  is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
-
   is-regexp@1.0.0:
     resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
     engines: {node: '>=0.10.0'}
@@ -5389,23 +5323,27 @@ packages:
   is-what@3.14.1:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
 
-  is-wsl@3.1.0:
-    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+  is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
-  isbinaryfile@4.0.10:
-    resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
-    engines: {node: '>= 8.0.0'}
-
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  isexe@3.1.1:
-    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
-    engines: {node: '>=16'}
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
+
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
 
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
@@ -5432,10 +5370,6 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
-  jackspeak@4.1.1:
-    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
-    engines: {node: 20 || >=22}
 
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -5489,6 +5423,10 @@ packages:
     resolution: {integrity: sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  json-parse-even-better-errors@5.0.0:
+    resolution: {integrity: sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -5504,6 +5442,9 @@ packages:
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
+  json-with-bigint@3.5.7:
+    resolution: {integrity: sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -5511,9 +5452,6 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
-
-  jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -5528,11 +5466,6 @@ packages:
 
   karma-source-map-support@1.4.0:
     resolution: {integrity: sha512-RsBECncGO17KAoJCYXjv+ckIz+Ii9NCi+9enk+rq6XC81ezYkb4/RHE6CTXdA7IOJqoF3wcaLfVG0CPmE5ca6A==}
-
-  karma@6.4.4:
-    resolution: {integrity: sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==}
-    engines: {node: '>= 10'}
-    hasBin: true
 
   keyux@0.7.2:
     resolution: {integrity: sha512-Z8ULf9BhSx1hI2rKG2uNjcvMgQmza97ZW2w43phS5VaT4wiTka7tOL4i/GJSc79k65tbvpoTVNCZwam0pqoH6A==}
@@ -5549,8 +5482,8 @@ packages:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
 
-  launch-editor@2.11.1:
-    resolution: {integrity: sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==}
+  launch-editor@2.13.1:
+    resolution: {integrity: sha512-lPSddlAAluRKJ7/cjRFoXUFzaX7q/YKI7yPHuEvSJVqoXvFnJov1/Ud87Aa4zULIbA9Nja4mSPK8l0z/7eV2wA==}
 
   lazy-ass@1.6.0:
     resolution: {integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==}
@@ -5574,9 +5507,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  less@4.4.2:
-    resolution: {integrity: sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==}
-    engines: {node: '>=14'}
+  less@4.6.4:
+    resolution: {integrity: sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   levn@0.4.1:
@@ -5673,10 +5606,6 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
-  log4js@6.9.1:
-    resolution: {integrity: sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==}
-    engines: {node: '>=8.0'}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -5686,8 +5615,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.2.2:
-    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -5703,8 +5632,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.5.1:
-    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -5725,8 +5654,8 @@ packages:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  make-fetch-happen@15.0.2:
-    resolution: {integrity: sha512-sI1NY4lWlXBAfjmCtVWIIpBypbBdhHtcjnwnv+gtCnsaOffyFil3aidszGC8hgzJe+fT1qix05sWxmD/Bmf/oQ==}
+  make-fetch-happen@15.0.4:
+    resolution: {integrity: sha512-vM2sG+wbVeVGYcCm16mM3d5fuem9oC28n436HjsGO3LcxoTI8LNVa4rwZDn3f76+cWyT4GGJDxjTYU1I2nr6zw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   map-stream@0.1.0:
@@ -5742,8 +5671,8 @@ packages:
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
-  mdast-util-from-markdown@2.0.2:
-    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
   mdast-util-frontmatter@2.0.1:
     resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
@@ -5784,15 +5713,17 @@ packages:
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
-  mdn-data@2.12.2:
-    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
-  memfs@4.51.0:
-    resolution: {integrity: sha512-4zngfkVM/GpIhC8YazOsM6E8hoB33NP0BCESPOA6z7qaL6umPJNqkO8CNYaLV2FB2MV6H1O3x2luHHOSqppv+A==}
+  memfs@4.56.11:
+    resolution: {integrity: sha512-/GodtwVeKVIHZKLUSr2ZdOxKBC5hHki4JNCU22DoCGPEHr5o2PD5U721zvESKyWwCfTfavFl9WZYgA13OAYK0g==}
+    peerDependencies:
+      tslib: '2'
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
@@ -5916,11 +5847,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  mime@2.6.0:
-    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
-    engines: {node: '>=4.0.0'}
-    hasBin: true
-
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -5929,14 +5855,14 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  mini-css-extract-plugin@2.9.2:
-    resolution: {integrity: sha512-GJuACcS//jtq4kCtd5ii/M0SZf7OZRH+BxdqXZHaJfb8TJiVl+NgQRPwiYt2EuqeSkNydn/7vP+bcE27C5mb9w==}
+  mini-css-extract-plugin@2.10.1:
+    resolution: {integrity: sha512-k7G3Y5QOegl380tXmZ68foBRRjE9Ljavx835ObdvmZjQ639izvZD8CS7BkWw1qKPPzHsGL/JDhl0uyU1zc2rJw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.104.1
 
-  mini-css-extract-plugin@2.9.4:
-    resolution: {integrity: sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==}
+  mini-css-extract-plugin@2.9.2:
+    resolution: {integrity: sha512-GJuACcS//jtq4kCtd5ii/M0SZf7OZRH+BxdqXZHaJfb8TJiVl+NgQRPwiYt2EuqeSkNydn/7vP+bcE27C5mb9w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.104.1
@@ -5944,15 +5870,15 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
-  minimatch@10.2.2:
-    resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.3:
-    resolution: {integrity: sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==}
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@9.0.6:
-    resolution: {integrity: sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
@@ -5966,6 +5892,10 @@ packages:
     resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  minipass-fetch@5.0.2:
+    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   minipass-flush@1.0.5:
     resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
     engines: {node: '>= 8'}
@@ -5978,29 +5908,29 @@ packages:
     resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
     engines: {node: '>=8'}
 
+  minipass-sized@2.0.0:
+    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
+    engines: {node: '>=8'}
+
   minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
     engines: {node: '>=8'}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
-
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
 
-  mocha@11.7.4:
-    resolution: {integrity: sha512-1jYAaY8x0kAZ0XszLWu14pzsf4KV740Gld4HXkhNTXwcHx4AUEDkPzgEHg9CM5dVcW+zv036tjpsEbLraPJj4w==}
+  mocha@11.7.5:
+    resolution: {integrity: sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
@@ -6021,8 +5951,8 @@ packages:
     resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
     hasBin: true
 
-  msgpackr@1.11.5:
-    resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
+  msgpackr@1.11.9:
+    resolution: {integrity: sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==}
 
   multicast-dns@7.2.5:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
@@ -6044,8 +5974,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  needle@3.3.1:
-    resolution: {integrity: sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==}
+  needle@3.5.0:
+    resolution: {integrity: sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==}
     engines: {node: '>= 4.4.x'}
     hasBin: true
 
@@ -6091,20 +6021,27 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
-  node-gyp@11.4.2:
-    resolution: {integrity: sha512-3gD+6zsrLQH7DyYOUIutaauuXrcyxeTPyQuZQCQoNPZMHMMS5m4y0xclNpvYzoK3VNzuyxT6eF4mkIL4WSZ1eQ==}
+  node-gyp@11.5.0:
+    resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
-  node-releases@2.0.23:
-    resolution: {integrity: sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==}
+  node-gyp@12.2.0:
+    resolution: {integrity: sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
 
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+  node-releases@2.0.36:
+    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   normalize-path@3.0.0:
@@ -6119,24 +6056,36 @@ packages:
     resolution: {integrity: sha512-IxaQZDMsqfQ2Lz37VvyyEtKLe8FsRZuysmedy/N06TU1RyVppYKXrO4xIhR0F+7ubIBox6Q7nir6fQI3ej39iA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  npm-bundled@5.0.0:
+    resolution: {integrity: sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   npm-install-checks@7.1.2:
     resolution: {integrity: sha512-z9HJBCYw9Zr8BqXcllKIs5nI+QggAImbBdHphOzVYrz2CB4iQ6FzWyKmlqDZua+51nAu7FcemlbTc9VgQN5XDQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  npm-install-checks@8.0.0:
+    resolution: {integrity: sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-normalize-package-bin@4.0.0:
     resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  npm-normalize-package-bin@5.0.0:
+    resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   npm-package-arg@12.0.2:
     resolution: {integrity: sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  npm-package-arg@13.0.1:
-    resolution: {integrity: sha512-6zqls5xFvJbgFjB1B2U6yITtyGBjDBORB7suI4zA4T/sZ1OmkMFlaQSNB/4K0LtXNA1t4OprAFxPisadK5O2ag==}
+  npm-package-arg@13.0.2:
+    resolution: {integrity: sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  npm-packlist@10.0.2:
-    resolution: {integrity: sha512-DrIWNiWT0FTdDRjGOYfEEZUNe1IzaSZ+up7qBTKnrQDySpdmuOQvytrqQlpK5QrCA4IThMvL4wTumqaa1ZvVIQ==}
+  npm-packlist@10.0.4:
+    resolution: {integrity: sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-packlist@9.0.0:
@@ -6147,16 +6096,16 @@ packages:
     resolution: {integrity: sha512-r4fFa4FqYY8xaM7fHecQ9Z2nE9hgNfJR+EmoKv0+chvzWkBcORX3r0FpTByP+CbOVJDladMXnPQGVN8PBLGuTQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  npm-pick-manifest@11.0.1:
-    resolution: {integrity: sha512-HnU7FYSWbo7dTVHtK0G+BXbZ0aIfxz/aUCVLN0979Ec6rGUX5cJ6RbgVx5fqb5G31ufz+BVFA7y1SkRTPVNoVQ==}
+  npm-pick-manifest@11.0.3:
+    resolution: {integrity: sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-registry-fetch@18.0.2:
     resolution: {integrity: sha512-LeVMZBBVy+oQb5R6FDV9OlJCcWDU+al10oKpe+nsvcHnG24Z3uM3SvJYKfGJlfGjVU8v9liejCrUR/M5HO5NEQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  npm-registry-fetch@19.0.0:
-    resolution: {integrity: sha512-DFxSAemHUwT/POaXAOY4NJmEWBPB0oKbwD6FFDE9hnt1nORkt/FXvgjD4hQjoKoHw9u0Ezws9SPXwV7xE/Gyww==}
+  npm-registry-fetch@19.1.1:
+    resolution: {integrity: sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-run-path@4.0.1:
@@ -6165,10 +6114,6 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
-
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -6179,10 +6124,6 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
-  on-finished@2.3.0:
-    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
-    engines: {node: '>= 0.8'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -6215,8 +6156,8 @@ packages:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
 
-  ordered-binary@1.6.0:
-    resolution: {integrity: sha512-IQh2aMfMIDbPjI/8a3Edr+PiOpcsB7yo8NdW7aHWVaoR/pcDldunMvnnwbk/auPGqmKeAdxtZl7MHX/QmPwhvQ==}
+  ordered-binary@1.6.1:
+    resolution: {integrity: sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w==}
 
   ospath@1.2.2:
     resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
@@ -6249,8 +6190,8 @@ packages:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
-  p-map@7.0.3:
-    resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
+  p-map@7.0.4:
+    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
   p-retry@6.2.1:
@@ -6269,8 +6210,8 @@ packages:
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
-  pacote@21.0.3:
-    resolution: {integrity: sha512-itdFlanxO0nmQv4ORsvA9K1wv40IPfB9OmWqfaJWvoJ30VKyHsqNgDVeG+TVhI7Gk7XW8slUy7cA9r6dF5qohw==}
+  pacote@21.5.0:
+    resolution: {integrity: sha512-VtZ0SB8mb5Tzw3dXDfVAIjhyVKUHZkS/ZH9/5mpKenwC9sFOXNI0JI7kEF7IMkwOnsWMFrvAZHzx1T5fmrp9FQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
@@ -6310,9 +6251,9 @@ packages:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
+  path-expression-matcher@1.1.3:
+    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -6325,9 +6266,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -6381,10 +6322,6 @@ packages:
   piscina@4.9.2:
     resolution: {integrity: sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==}
 
-  pixelmatch@7.1.0:
-    resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
-    hasBin: true
-
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -6422,20 +6359,20 @@ packages:
     peerDependencies:
       postcss: ^8.4.38
 
-  postcss-colormin@7.0.4:
-    resolution: {integrity: sha512-ziQuVzQZBROpKpfeDwmrG+Vvlr0YWmY/ZAk99XD+mGEBuEojoFekL41NCsdhyNUtZI7DPOoIWIR7vQQK9xwluw==}
+  postcss-colormin@7.0.6:
+    resolution: {integrity: sha512-oXM2mdx6IBTRm39797QguYzVEWzbdlFiMNfq88fCCN1Wepw3CYmJ/1/Ifa/KjWo+j5ZURDl2NTldLJIw51IeNQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
 
-  postcss-convert-values@7.0.7:
-    resolution: {integrity: sha512-HR9DZLN04Xbe6xugRH6lS4ZQH2zm/bFh/ZyRkpedZozhvh+awAfbA0P36InO4fZfDhvYfNJeNvlTf1sjwGbw/A==}
+  postcss-convert-values@7.0.9:
+    resolution: {integrity: sha512-l6uATQATZaCa0bckHV+r6dLXfWtUBKXxO3jK+AtxxJJtgMPD+VhhPCCx51I4/5w8U5uHV67g3w7PXj+V3wlMlg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
 
-  postcss-discard-comments@7.0.4:
-    resolution: {integrity: sha512-6tCUoql/ipWwKtVP/xYiFf1U9QgJ0PUvxN7pTcsQ8Ns3Fnwq1pU5D5s1MhT/XySeLq6GXNvn37U46Ded0TckWg==}
+  postcss-discard-comments@7.0.6:
+    resolution: {integrity: sha512-Sq+Fzj1Eg5/CPf1ERb0wS1Im5cvE2gDXCE+si4HCn1sf+jpQZxDI4DXEp8t77B/ImzDceWE2ebJQFXdqZ6GRJw==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
@@ -6490,11 +6427,11 @@ packages:
       webpack:
         optional: true
 
-  postcss-loader@8.2.0:
-    resolution: {integrity: sha512-tHX+RkpsXVcc7st4dSdDGliI+r4aAQDuv+v3vFYHixb6YgjreG5AG4SEB0kDK8u2s6htqEEpKlkhSBUTvWKYnA==}
+  postcss-loader@8.2.1:
+    resolution: {integrity: sha512-k98jtRzthjj3f76MYTs9JTpRqV1RaaMhEU0Lpw9OTmQZQdppg4B30VZ74BojuBHt3F4KyubHJoXCMUeM8Bqeow==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 0.x || 1.x
+      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
       postcss: ^7.0.0 || ^8.0.1
       webpack: ^5.104.1
     peerDependenciesMeta:
@@ -6512,8 +6449,8 @@ packages:
     peerDependencies:
       postcss: ^8.4.32
 
-  postcss-merge-rules@7.0.6:
-    resolution: {integrity: sha512-2jIPT4Tzs8K87tvgCpSukRQ2jjd+hH6Bb8rEEOUDmmhOeTcqDg5fEFK8uKIu+Pvc3//sm3Uu6FRqfyv7YF7+BQ==}
+  postcss-merge-rules@7.0.8:
+    resolution: {integrity: sha512-BOR1iAM8jnr7zoQSlpeBmCsWV5Uudi/+5j7k05D0O/WP3+OFMPD86c1j/20xiuRtyt45bhxw/7hnhZNhW2mNFA==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
@@ -6530,14 +6467,14 @@ packages:
     peerDependencies:
       postcss: ^8.4.32
 
-  postcss-minify-params@7.0.4:
-    resolution: {integrity: sha512-3OqqUddfH8c2e7M35W6zIwv7jssM/3miF9cbCSb1iJiWvtguQjlxZGIHK9JRmc8XAKmE2PFGtHSM7g/VcW97sw==}
+  postcss-minify-params@7.0.6:
+    resolution: {integrity: sha512-YOn02gC68JijlaXVuKvFSCvQOhTpblkcfDre2hb/Aaa58r2BIaK4AtE/cyZf2wV7YKAG+UlP9DT+By0ry1E4VQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
 
-  postcss-minify-selectors@7.0.5:
-    resolution: {integrity: sha512-x2/IvofHcdIrAm9Q+p06ZD1h6FPcQ32WtCRVodJLDR+WMn8EVHI1kvLxZuGKz/9EY5nAmI6lIQIrpo4tBy5+ug==}
+  postcss-minify-selectors@7.0.6:
+    resolution: {integrity: sha512-lIbC0jy3AAwDxEgciZlBullDiMBeBCT+fz5G8RcA9MWqh/hfUkpOI3vNDUNEZHgokaoiv0juB9Y8fGcON7rU/A==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
@@ -6614,8 +6551,8 @@ packages:
     peerDependencies:
       postcss: ^8.4.32
 
-  postcss-normalize-unicode@7.0.4:
-    resolution: {integrity: sha512-LvIURTi1sQoZqj8mEIE8R15yvM+OhbR1avynMtI9bUzj5gGKR/gfZFd8O7VMj0QgJaIFzxDwxGl/ASMYAkqO8g==}
+  postcss-normalize-unicode@7.0.6:
+    resolution: {integrity: sha512-z6bwTV84YW6ZvvNoaNLuzRW4/uWxDKYI1iIDrzk6D2YTL7hICApy+Q1LP6vBEsljX8FM7YSuV9qI79XESd4ddQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
@@ -6638,8 +6575,8 @@ packages:
     peerDependencies:
       postcss: ^8.4.32
 
-  postcss-reduce-initial@7.0.4:
-    resolution: {integrity: sha512-rdIC9IlMBn7zJo6puim58Xd++0HdbvHeHaPgXsimMfG1ijC5A9ULvNLSE0rUKVJOvNMcwewW4Ga21ngyJjY/+Q==}
+  postcss-reduce-initial@7.0.6:
+    resolution: {integrity: sha512-G6ZyK68AmrPdMB6wyeA37ejnnRG2S8xinJrZJnOv+IaRKf6koPAVbQsiC7MfkmXaGmF1UO+QCijb27wfpxuRNg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
@@ -6650,8 +6587,8 @@ packages:
     peerDependencies:
       postcss: ^8.4.32
 
-  postcss-selector-parser@7.1.0:
-    resolution: {integrity: sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==}
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
   postcss-simple-vars@7.0.1:
@@ -6660,14 +6597,14 @@ packages:
     peerDependencies:
       postcss: ^8.2.1
 
-  postcss-svgo@7.1.0:
-    resolution: {integrity: sha512-KnAlfmhtoLz6IuU3Sij2ycusNs4jPW+QoFE5kuuUOK8awR6tMxZQrs5Ey3BUz7nFCzT3eqyFgqkyrHiaU2xx3w==}
+  postcss-svgo@7.1.1:
+    resolution: {integrity: sha512-zU9H9oEDrUFKa0JB7w+IYL7Qs9ey1mZyjhbf0KLxwJDdDRtoPvCmaEfknzqfHj44QS9VD6c5sJnBAVYTLRg/Sg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >= 18}
     peerDependencies:
       postcss: ^8.4.32
 
-  postcss-unique-selectors@7.0.4:
-    resolution: {integrity: sha512-pmlZjsmEAG7cHd7uK3ZiNSW6otSZ13RHuZ/4cDN/bVglS5EpF2r2oxY99SuOHa8m7AWoBCelTS3JPpzsIs8skQ==}
+  postcss-unique-selectors@7.0.5:
+    resolution: {integrity: sha512-3QoYmEt4qg/rUWDn6Tc8+ZVPmbp4G1hXDtCNWDx0st8SjtCbRcxRXDDM1QrEiXGG3A45zscSJFb4QH90LViyxg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
@@ -6679,8 +6616,8 @@ packages:
     resolution: {integrity: sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -6694,6 +6631,10 @@ packages:
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -6731,19 +6672,16 @@ packages:
     engines: {node: '>= 0.10'}
     hasBin: true
 
-  pump@3.0.3:
-    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
-
-  punycode@1.4.1:
-    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qjobs@1.2.0:
-    resolution: {integrity: sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==}
-    engines: {node: '>=0.9'}
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
@@ -6761,10 +6699,6 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-
-  raw-body@2.5.2:
-    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
-    engines: {node: '>= 0.8'}
 
   raw-body@2.5.3:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
@@ -6894,6 +6828,11 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  resolve@1.22.11:
+    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
@@ -6917,13 +6856,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
-  rimraf@6.0.1:
-    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
+  rimraf@6.1.3:
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
     hasBin: true
 
@@ -6959,10 +6893,6 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  safe-regex-test@1.1.0:
-    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
-    engines: {node: '>= 0.4'}
-
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -6992,13 +6922,14 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  sass@1.93.2:
-    resolution: {integrity: sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==}
+  sass@1.98.0:
+    resolution: {integrity: sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  sax@1.4.1:
-    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+  sax@1.5.0:
+    resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
+    engines: {node: '>=11.0.0'}
 
   schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
@@ -7035,28 +6966,25 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
-  send@0.19.0:
-    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
-  serve-index@1.9.1:
-    resolution: {integrity: sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==}
+  serve-index@1.9.2:
+    resolution: {integrity: sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==}
     engines: {node: '>= 0.8.0'}
 
-  serve-static@1.16.2:
-    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
-
-  setprototypeof@1.1.0:
-    resolution: {integrity: sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -7114,12 +7042,12 @@ packages:
     resolution: {integrity: sha512-ZpzWAFHIFqyFE56dXqgX/DkDRZdz+rRcjoIk/RQU4IX0wiCv1l8S7ZrXDHcCc+uaf+6o7w3h2l3g6GYG5TKN9Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  sigstore@4.0.0:
-    resolution: {integrity: sha512-Gw/FgHtrLM9WP8P5lLcSGh9OQcrTruWCELAiS48ik1QbL0cH+dfjomiRTUE9zzz+D1N6rOLkwXUvVmXZAsNE0Q==}
+  sigstore@4.1.0:
+    resolution: {integrity: sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  simple-git@3.28.0:
-    resolution: {integrity: sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==}
+  simple-git@3.33.0:
+    resolution: {integrity: sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -7153,9 +7081,6 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  socket.io-adapter@2.5.6:
-    resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
-
   socket.io-client@4.7.0:
     resolution: {integrity: sha512-7Q8CeDrhuZzg4QLXl3tXlk5yb086oxYzehAVZRLiGCzCmtDneiHz1qHyyWcxhTgxXiokVpWQXoG/u60HoXSQew==}
     engines: {node: '>=10.0.0'}
@@ -7163,10 +7088,6 @@ packages:
   socket.io-parser@4.2.5:
     resolution: {integrity: sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==}
     engines: {node: '>=10.0.0'}
-
-  socket.io@4.8.3:
-    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
-    engines: {node: '>=10.2.0'}
 
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
@@ -7219,8 +7140,11 @@ packages:
   spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
 
-  spdx-license-ids@3.0.22:
-    resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
@@ -7248,6 +7172,10 @@ packages:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  ssri@13.0.1:
+    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -7260,23 +7188,15 @@ packages:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
 
-  statuses@2.0.1:
-    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
-    engines: {node: '>= 0.8'}
-
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stream-combiner@0.0.4:
     resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
-
-  streamroller@3.1.5:
-    resolution: {integrity: sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==}
-    engines: {node: '>=8.0'}
 
   string-argv@0.3.1:
     resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
@@ -7311,8 +7231,8 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-ansi@7.1.2:
-    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
   strip-bom-string@1.0.0:
@@ -7342,11 +7262,11 @@ packages:
     peerDependencies:
       webpack: ^5.104.1
 
-  style-mod@4.1.2:
-    resolution: {integrity: sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==}
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
-  stylehacks@7.0.6:
-    resolution: {integrity: sha512-iitguKivmsueOmTO0wmxURXBP8uqOO+zikLGZ7Mm9e/94R4w5T999Js2taS/KBOnQ/wdC3jN3vNSrkGDrlnqQg==}
+  stylehacks@7.0.8:
+    resolution: {integrity: sha512-I3f053GBLIiS5Fg6OMFhq/c+yW+5Hc2+1fgq7gElDMMSqwlRb3tBf2ef6ucLStYRpId4q//bQO1FjcyNyy4yDQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.32
@@ -7369,8 +7289,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svgo@4.0.0:
-    resolution: {integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==}
+  svgo@4.0.1:
+    resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -7382,12 +7302,12 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tar@7.5.9:
-    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
+  tar@7.5.11:
+    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
     engines: {node: '>=18'}
 
-  terser-webpack-plugin@5.3.16:
-    resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
+  terser-webpack-plugin@5.4.0:
+    resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -7407,8 +7327,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  terser@5.44.0:
-    resolution: {integrity: sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==}
+  terser@5.46.0:
+    resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -7433,16 +7353,16 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
@@ -7491,8 +7411,8 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+  ts-api-utils@2.4.0:
+    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -7524,8 +7444,8 @@ packages:
     resolution: {integrity: sha512-3T3T04WzowbwV2FDiGXBbr81t64g1MUGGJRgT4x5o97N+8ArdhVCAF9IxFrxuSJmM3E5Asn7nKHkao0ibcZXAg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  tuf-js@4.0.0:
-    resolution: {integrity: sha512-Lq7ieeGvXDXwpoSmOSgLWVdsGGV9J4a77oDTAPe/Ltrqnnm/ETaRlBAQTH5JatEh8KXuE6sddf9qAv1Q2282Hg==}
+  tuf-js@4.1.0:
+    resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   tunnel-agent@0.6.0:
@@ -7549,20 +7469,16 @@ packages:
   typed-assert@1.0.9:
     resolution: {integrity: sha512-KNNZtayBCtmnNmbo5mG47p1XsCyrx6iVqomjcZnec/1Y5GGARaxPs6r49RnSPeUP3YjNYiU9sQHAtY4BBvnZwg==}
 
-  typescript-eslint@8.46.1:
-    resolution: {integrity: sha512-VHgijW803JafdSsDO8I761r3SHrgk4T00IdyQ+/UsthtgPRsBWQLqoSxOolxTpxRKi1kGXK0bSz4CoAc9ObqJA==}
+  typescript-eslint@8.57.0:
+    resolution: {integrity: sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   typescript@5.5.4:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
-    hasBin: true
-
-  ua-parser-js@0.7.41:
-    resolution: {integrity: sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==}
     hasBin: true
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -7592,15 +7508,23 @@ packages:
     resolution: {integrity: sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  unique-filename@5.0.0:
+    resolution: {integrity: sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   unique-slug@5.0.0:
     resolution: {integrity: sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  unique-slug@6.0.0:
+    resolution: {integrity: sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
-  unist-util-is@6.0.0:
-    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
@@ -7608,18 +7532,17 @@ packages:
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
 
-  unist-util-visit-parents@6.0.1:
-    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
-
-  universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -7636,12 +7559,6 @@ packages:
   upath@2.0.1:
     resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
     engines: {node: '>=4'}
-
-  update-browserslist-db@1.1.3:
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -7676,6 +7593,10 @@ packages:
   validate-npm-package-name@6.0.2:
     resolution: {integrity: sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  validate-npm-package-name@7.0.2:
+    resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   vanilla-colorful@0.7.2:
     resolution: {integrity: sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg==}
@@ -7734,20 +7655,21 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.0.18:
-    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.18
-      '@vitest/browser-preview': 4.0.18
-      '@vitest/browser-webdriverio': 4.0.18
-      '@vitest/ui': 4.0.18
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -7767,10 +7689,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  void-elements@2.0.1:
-    resolution: {integrity: sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==}
-    engines: {node: '>=0.10.0'}
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
@@ -7850,8 +7768,8 @@ packages:
   webpack-sources@1.4.3:
     resolution: {integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==}
 
-  webpack-sources@3.3.3:
-    resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
+  webpack-sources@3.3.4:
+    resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
     engines: {node: '>=10.13.0'}
 
   webpack-subresource-integrity@5.1.0:
@@ -7864,8 +7782,8 @@ packages:
       html-webpack-plugin:
         optional: true
 
-  webpack@5.105.2:
-    resolution: {integrity: sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==}
+  webpack@5.105.4:
+    resolution: {integrity: sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -7890,6 +7808,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   why-is-node-running@2.3.0:
@@ -7938,8 +7861,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7972,14 +7895,10 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
     hasBin: true
-
-  yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -7987,10 +7906,6 @@ packages:
 
   yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
-    engines: {node: '>=10'}
-
-  yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
     engines: {node: '>=10'}
 
   yargs@17.7.2:
@@ -8008,8 +7923,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  yocto-queue@1.2.1:
-    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
   yoctocolors-cjs@2.1.3:
@@ -8029,41 +7944,38 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@analogjs/vite-plugin-angular@2.2.3(@angular-devkit/build-angular@19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1))(@angular/build@19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.6)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1))':
+  '@analogjs/vite-plugin-angular@2.3.1(@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2))(@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.8)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2))':
     dependencies:
+      tinyglobby: 0.2.15
       ts-morph: 21.0.1
     optionalDependencies:
-      '@angular-devkit/build-angular': 19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1)
-      '@angular/build': 19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.6)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1)
+      '@angular-devkit/build-angular': 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2)
+      '@angular/build': 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.8)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2)
 
-  '@analogjs/vitest-angular@2.2.3(ea499e6060c9e668453fb89aea7ad742)':
+  '@analogjs/vitest-angular@2.3.1(d014764e7ce56e7bffbd51c6d32db63d)':
     dependencies:
-      '@analogjs/vite-plugin-angular': 2.2.3(@angular-devkit/build-angular@19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1))(@angular/build@19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.6)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1))
-      '@angular-devkit/architect': 0.1902.20(chokidar@4.0.3)
-      vitest: 4.0.18(@types/node@14.18.63)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1)
+      '@analogjs/vite-plugin-angular': 2.3.1(@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2))(@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.8)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2))
+      '@angular-devkit/architect': 0.1902.22(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.22(chokidar@4.0.3)
+      vitest: 4.1.0(@types/node@14.18.63)(@vitest/browser-playwright@4.1.0)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
+    optionalDependencies:
+      zone.js: 0.15.1
 
-  '@angular-devkit/architect@0.1902.19(chokidar@4.0.3)':
+  '@angular-devkit/architect@0.1902.22(chokidar@4.0.3)':
     dependencies:
-      '@angular-devkit/core': 19.2.19(chokidar@4.0.3)
+      '@angular-devkit/core': 19.2.22(chokidar@4.0.3)
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/architect@0.1902.20(chokidar@4.0.3)':
-    dependencies:
-      '@angular-devkit/core': 19.2.20(chokidar@4.0.3)
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - chokidar
-
-  '@angular-devkit/build-angular@19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1)':
+  '@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1902.19(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.1902.19(chokidar@4.0.3)(webpack-dev-server@5.2.2)(webpack@5.105.2)
-      '@angular-devkit/core': 19.2.19(chokidar@4.0.3)
-      '@angular/build': 19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.2)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1)
-      '@angular/compiler-cli': 19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4)
+      '@angular-devkit/architect': 0.1902.22(chokidar@4.0.3)
+      '@angular-devkit/build-webpack': 0.1902.22(chokidar@4.0.3)(webpack-dev-server@5.2.2)(webpack@5.105.4)
+      '@angular-devkit/core': 19.2.22(chokidar@4.0.3)
+      '@angular/build': 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.2)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2)
+      '@angular/compiler-cli': 19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4)
       '@babel/core': 7.26.10
       '@babel/generator': 7.26.10
       '@babel/helper-annotate-as-pure': 7.25.9
@@ -8074,14 +7986,14 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
       '@babel/runtime': 7.26.10
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(typescript@5.5.4)(webpack@5.105.2)
-      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))
+      '@ngtools/webpack': 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(typescript@5.5.4)(webpack@5.105.4)
+      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.20(postcss@8.5.2)
-      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.105.2)
-      browserslist: 4.26.3
-      copy-webpack-plugin: 12.0.2(webpack@5.105.2)
-      css-loader: 7.1.2(webpack@5.105.2)
+      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.105.4)
+      browserslist: 4.28.1
+      copy-webpack-plugin: 12.0.2(webpack@5.105.4)
+      css-loader: 7.1.2(webpack@5.105.4)
       esbuild-wasm: 0.25.4
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -8089,36 +8001,35 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.2.2
-      less-loader: 12.2.0(less@4.2.2)(webpack@5.105.2)
-      license-webpack-plugin: 4.0.2(webpack@5.105.2)
+      less-loader: 12.2.0(less@4.2.2)(webpack@5.105.4)
+      license-webpack-plugin: 4.0.2(webpack@5.105.4)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.2(webpack@5.105.2)
+      mini-css-extract-plugin: 2.9.2(webpack@5.105.4)
       open: 10.1.0
       ora: 5.4.1
       picomatch: 4.0.2
       piscina: 4.8.0
       postcss: 8.5.2
-      postcss-loader: 8.1.1(postcss@8.5.2)(typescript@5.5.4)(webpack@5.105.2)
+      postcss-loader: 8.1.1(postcss@8.5.2)(typescript@5.5.4)(webpack@5.105.4)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.85.0
-      sass-loader: 16.0.5(sass@1.85.0)(webpack@5.105.2)
+      sass-loader: 16.0.5(sass@1.85.0)(webpack@5.105.4)
       semver: 7.7.1
-      source-map-loader: 5.0.0(webpack@5.105.2)
+      source-map-loader: 5.0.0(webpack@5.105.4)
       source-map-support: 0.5.21
       terser: 5.39.0
       tree-kill: 1.2.2
       tslib: 2.8.1
       typescript: 5.5.4
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
-      webpack-dev-middleware: 7.4.2(webpack@5.105.2)
-      webpack-dev-server: 5.2.2(webpack-cli@5.1.4)(webpack@5.105.2)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack-dev-middleware: 7.4.2(tslib@2.8.1)(webpack@5.105.4)
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.2)
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.4)
     optionalDependencies:
       esbuild: 0.25.4
-      karma: 6.4.4
-      ng-packagr: 19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
+      ng-packagr: 19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - '@angular/compiler'
       - '@rspack/core'
@@ -8142,16 +8053,16 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.1902.19(chokidar@4.0.3)(webpack-dev-server@5.2.2)(webpack@5.105.2)':
+  '@angular-devkit/build-webpack@0.1902.22(chokidar@4.0.3)(webpack-dev-server@5.2.2)(webpack@5.105.4)':
     dependencies:
-      '@angular-devkit/architect': 0.1902.19(chokidar@4.0.3)
+      '@angular-devkit/architect': 0.1902.22(chokidar@4.0.3)
       rxjs: 7.8.1
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
-      webpack-dev-server: 5.2.2(webpack-cli@5.1.4)(webpack@5.105.2)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4)
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/core@19.2.19(chokidar@4.0.3)':
+  '@angular-devkit/core@19.2.22(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
@@ -8162,20 +8073,9 @@ snapshots:
     optionalDependencies:
       chokidar: 4.0.3
 
-  '@angular-devkit/core@19.2.20(chokidar@4.0.3)':
+  '@angular-devkit/schematics@19.2.22(chokidar@4.0.3)':
     dependencies:
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      jsonc-parser: 3.3.1
-      picomatch: 4.0.2
-      rxjs: 7.8.1
-      source-map: 0.7.4
-    optionalDependencies:
-      chokidar: 4.0.3
-
-  '@angular-devkit/schematics@19.2.20(chokidar@4.0.3)':
-    dependencies:
-      '@angular-devkit/core': 19.2.20(chokidar@4.0.3)
+      '@angular-devkit/core': 19.2.22(chokidar@4.0.3)
       jsonc-parser: 3.3.1
       magic-string: 0.30.17
       ora: 5.4.1
@@ -8183,24 +8083,24 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))':
+  '@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))':
     dependencies:
-      '@angular/common': 19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
-      '@angular/core': 19.2.19(rxjs@6.6.7)(zone.js@0.15.1)
+      '@angular/common': 19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
+      '@angular/core': 19.2.20(rxjs@6.6.7)(zone.js@0.15.1)
       tslib: 2.8.1
 
-  '@angular/build@19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.2)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1)':
+  '@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.2)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1902.19(chokidar@4.0.3)
-      '@angular/compiler': 19.2.19
-      '@angular/compiler-cli': 19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4)
+      '@angular-devkit/architect': 0.1902.22(chokidar@4.0.3)
+      '@angular/compiler': 19.2.20
+      '@angular/compiler-cli': 19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4)
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.10)
       '@inquirer/confirm': 5.1.6(@types/node@14.18.63)
-      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))
+      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
       beasties: 0.3.2
       browserslist: 4.28.1
       esbuild: 0.25.4
@@ -8218,13 +8118,12 @@ snapshots:
       semver: 7.7.1
       source-map-support: 0.5.21
       typescript: 5.5.4
-      vite: 6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2)
       watchpack: 2.4.2
     optionalDependencies:
-      karma: 6.4.4
       less: 4.2.2
       lmdb: 3.2.6
-      ng-packagr: 19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
+      ng-packagr: 19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
       postcss: 8.5.2
     transitivePeerDependencies:
       - '@types/node'
@@ -8239,18 +8138,18 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(@angular/compiler@19.2.19)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.6)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1)':
+  '@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.8)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1902.19(chokidar@4.0.3)
-      '@angular/compiler': 19.2.19
-      '@angular/compiler-cli': 19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4)
+      '@angular-devkit/architect': 0.1902.22(chokidar@4.0.3)
+      '@angular/compiler': 19.2.20
+      '@angular/compiler-cli': 19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4)
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.10)
       '@inquirer/confirm': 5.1.6(@types/node@14.18.63)
-      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))
+      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
       beasties: 0.3.2
       browserslist: 4.28.1
       esbuild: 0.25.4
@@ -8268,14 +8167,13 @@ snapshots:
       semver: 7.7.1
       source-map-support: 0.5.21
       typescript: 5.5.4
-      vite: 6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2)
       watchpack: 2.4.2
     optionalDependencies:
-      karma: 6.4.4
       less: 4.2.2
       lmdb: 3.2.6
-      ng-packagr: 19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
-      postcss: 8.5.6
+      ng-packagr: 19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
+      postcss: 8.5.8
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -8290,14 +8188,14 @@ snapshots:
       - yaml
     optional: true
 
-  '@angular/cli@19.2.20(@types/node@14.18.63)(chokidar@4.0.3)':
+  '@angular/cli@19.2.22(@types/node@14.18.63)(chokidar@4.0.3)':
     dependencies:
-      '@angular-devkit/architect': 0.1902.20(chokidar@4.0.3)
-      '@angular-devkit/core': 19.2.20(chokidar@4.0.3)
-      '@angular-devkit/schematics': 19.2.20(chokidar@4.0.3)
+      '@angular-devkit/architect': 0.1902.22(chokidar@4.0.3)
+      '@angular-devkit/core': 19.2.22(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.22(chokidar@4.0.3)
       '@inquirer/prompts': 7.3.2(@types/node@14.18.63)
       '@listr2/prompt-adapter-inquirer': 2.0.18(@inquirer/prompts@7.3.2(@types/node@14.18.63))
-      '@schematics/angular': 19.2.20(chokidar@4.0.3)
+      '@schematics/angular': 19.2.22(chokidar@4.0.3)
       '@yarnpkg/lockfile': 1.1.0
       ini: 5.0.0
       jsonc-parser: 3.3.1
@@ -8314,75 +8212,75 @@ snapshots:
       - chokidar
       - supports-color
 
-  '@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)':
+  '@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)':
     dependencies:
-      '@angular/core': 19.2.19(rxjs@6.6.7)(zone.js@0.15.1)
+      '@angular/core': 19.2.20(rxjs@6.6.7)(zone.js@0.15.1)
       rxjs: 6.6.7
       tslib: 2.8.1
 
-  '@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4)':
+  '@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4)':
     dependencies:
-      '@angular/compiler': 19.2.19
+      '@angular/compiler': 19.2.20
       '@babel/core': 7.26.9
       '@jridgewell/sourcemap-codec': 1.5.5
       chokidar: 4.0.3
       convert-source-map: 1.9.0
       reflect-metadata: 0.2.2
-      semver: 7.7.3
+      semver: 7.7.4
       tslib: 2.8.1
       typescript: 5.5.4
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
 
-  '@angular/compiler@19.2.19':
+  '@angular/compiler@19.2.20':
     dependencies:
       tslib: 2.8.1
 
-  '@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)':
+  '@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)':
     dependencies:
       rxjs: 6.6.7
       tslib: 2.8.1
       zone.js: 0.15.1
 
-  '@angular/forms@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(rxjs@6.6.7)':
+  '@angular/forms@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(rxjs@6.6.7)':
     dependencies:
-      '@angular/common': 19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
-      '@angular/core': 19.2.19(rxjs@6.6.7)(zone.js@0.15.1)
-      '@angular/platform-browser': 19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))
+      '@angular/common': 19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
+      '@angular/core': 19.2.20(rxjs@6.6.7)(zone.js@0.15.1)
+      '@angular/platform-browser': 19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))
       rxjs: 6.6.7
       tslib: 2.8.1
 
-  '@angular/language-service@19.2.19': {}
+  '@angular/language-service@19.2.20': {}
 
-  '@angular/platform-browser-dynamic@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/compiler@19.2.19)(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))':
+  '@angular/platform-browser-dynamic@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/compiler@19.2.20)(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))':
     dependencies:
-      '@angular/common': 19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
-      '@angular/compiler': 19.2.19
-      '@angular/core': 19.2.19(rxjs@6.6.7)(zone.js@0.15.1)
-      '@angular/platform-browser': 19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))
+      '@angular/common': 19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
+      '@angular/compiler': 19.2.20
+      '@angular/core': 19.2.20(rxjs@6.6.7)(zone.js@0.15.1)
+      '@angular/platform-browser': 19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))
       tslib: 2.8.1
 
-  '@angular/platform-browser@19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))':
+  '@angular/platform-browser@19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))':
     dependencies:
-      '@angular/common': 19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
-      '@angular/core': 19.2.19(rxjs@6.6.7)(zone.js@0.15.1)
+      '@angular/common': 19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
+      '@angular/core': 19.2.20(rxjs@6.6.7)(zone.js@0.15.1)
       tslib: 2.8.1
     optionalDependencies:
-      '@angular/animations': 19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))
+      '@angular/animations': 19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))
 
-  '@angular/router@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(rxjs@6.6.7)':
+  '@angular/router@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(rxjs@6.6.7)':
     dependencies:
-      '@angular/common': 19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
-      '@angular/core': 19.2.19(rxjs@6.6.7)(zone.js@0.15.1)
-      '@angular/platform-browser': 19.2.19(@angular/animations@19.2.19(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.19(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.19(rxjs@6.6.7)(zone.js@0.15.1))
+      '@angular/common': 19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7)
+      '@angular/core': 19.2.20(rxjs@6.6.7)(zone.js@0.15.1)
+      '@angular/platform-browser': 19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))
       rxjs: 6.6.7
       tslib: 2.8.1
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       tslib: 2.8.1
 
   '@aws-crypto/sha256-browser@5.2.0':
@@ -8390,15 +8288,15 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.5
-      '@aws-sdk/util-locate-window': 3.893.0
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -8407,7 +8305,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -8415,230 +8313,230 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/credential-provider-node': 3.972.18
-      '@aws-sdk/eventstream-handler-node': 3.972.10
-      '@aws-sdk/middleware-eventstream': 3.972.7
-      '@aws-sdk/middleware-host-header': 3.972.7
-      '@aws-sdk/middleware-logger': 3.972.7
-      '@aws-sdk/middleware-recursion-detection': 3.972.7
-      '@aws-sdk/middleware-user-agent': 3.972.19
-      '@aws-sdk/middleware-websocket': 3.972.12
-      '@aws-sdk/region-config-resolver': 3.972.7
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/credential-provider-node': 3.972.21
+      '@aws-sdk/eventstream-handler-node': 3.972.11
+      '@aws-sdk/middleware-eventstream': 3.972.8
+      '@aws-sdk/middleware-host-header': 3.972.8
+      '@aws-sdk/middleware-logger': 3.972.8
+      '@aws-sdk/middleware-recursion-detection': 3.972.8
+      '@aws-sdk/middleware-user-agent': 3.972.21
+      '@aws-sdk/middleware-websocket': 3.972.13
+      '@aws-sdk/region-config-resolver': 3.972.8
       '@aws-sdk/token-providers': 3.994.0
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.994.0
-      '@aws-sdk/util-user-agent-browser': 3.972.7
-      '@aws-sdk/util-user-agent-node': 3.973.4
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.9
-      '@smithy/eventstream-serde-browser': 4.2.11
-      '@smithy/eventstream-serde-config-resolver': 4.3.11
-      '@smithy/eventstream-serde-node': 4.2.11
-      '@smithy/fetch-http-handler': 5.3.13
-      '@smithy/hash-node': 4.2.11
-      '@smithy/invalid-dependency': 4.2.11
-      '@smithy/middleware-content-length': 4.2.11
-      '@smithy/middleware-endpoint': 4.4.23
-      '@smithy/middleware-retry': 4.4.40
-      '@smithy/middleware-serde': 4.2.12
-      '@smithy/middleware-stack': 4.2.11
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.14
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.11
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.39
-      '@smithy/util-defaults-mode-node': 4.2.42
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.11
-      '@smithy/util-stream': 4.5.17
-      '@smithy/util-utf8': 4.2.0
+      '@aws-sdk/util-user-agent-browser': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.973.7
+      '@smithy/config-resolver': 4.4.11
+      '@smithy/core': 3.23.11
+      '@smithy/eventstream-serde-browser': 4.2.12
+      '@smithy/eventstream-serde-config-resolver': 4.3.12
+      '@smithy/eventstream-serde-node': 4.2.12
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.25
+      '@smithy/middleware-retry': 4.4.42
+      '@smithy/middleware-serde': 4.2.14
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.4.16
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.41
+      '@smithy/util-defaults-mode-node': 4.2.44
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
+      '@smithy/util-stream': 4.5.19
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.973.18':
+  '@aws-sdk/core@3.973.20':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@aws-sdk/xml-builder': 3.972.10
-      '@smithy/core': 3.23.9
-      '@smithy/node-config-provider': 4.3.11
-      '@smithy/property-provider': 4.2.11
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/signature-v4': 5.3.11
-      '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.13.0
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/xml-builder': 3.972.11
+      '@smithy/core': 3.23.11
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
-      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-middleware': 4.2.12
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.16':
+  '@aws-sdk/credential-provider-env@3.972.18':
     dependencies:
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.11
-      '@smithy/types': 4.13.0
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.18':
+  '@aws-sdk/credential-provider-http@3.972.20':
     dependencies:
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/types': 3.973.5
-      '@smithy/fetch-http-handler': 5.3.13
-      '@smithy/node-http-handler': 4.4.14
-      '@smithy/property-provider': 4.2.11
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.13.0
-      '@smithy/util-stream': 4.5.17
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/types': 3.973.6
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/node-http-handler': 4.4.16
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      '@smithy/util-stream': 4.5.19
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.17':
+  '@aws-sdk/credential-provider-ini@3.972.20':
     dependencies:
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/credential-provider-env': 3.972.16
-      '@aws-sdk/credential-provider-http': 3.972.18
-      '@aws-sdk/credential-provider-login': 3.972.17
-      '@aws-sdk/credential-provider-process': 3.972.16
-      '@aws-sdk/credential-provider-sso': 3.972.17
-      '@aws-sdk/credential-provider-web-identity': 3.972.17
-      '@aws-sdk/nested-clients': 3.996.7
-      '@aws-sdk/types': 3.973.5
-      '@smithy/credential-provider-imds': 4.2.11
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-login@3.972.17':
-    dependencies:
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/nested-clients': 3.996.7
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.11
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/credential-provider-env': 3.972.18
+      '@aws-sdk/credential-provider-http': 3.972.20
+      '@aws-sdk/credential-provider-login': 3.972.20
+      '@aws-sdk/credential-provider-process': 3.972.18
+      '@aws-sdk/credential-provider-sso': 3.972.20
+      '@aws-sdk/credential-provider-web-identity': 3.972.20
+      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/types': 3.973.6
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.18':
+  '@aws-sdk/credential-provider-login@3.972.20':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.16
-      '@aws-sdk/credential-provider-http': 3.972.18
-      '@aws-sdk/credential-provider-ini': 3.972.17
-      '@aws-sdk/credential-provider-process': 3.972.16
-      '@aws-sdk/credential-provider-sso': 3.972.17
-      '@aws-sdk/credential-provider-web-identity': 3.972.17
-      '@aws-sdk/types': 3.973.5
-      '@smithy/credential-provider-imds': 4.2.11
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.16':
+  '@aws-sdk/credential-provider-node@3.972.21':
     dependencies:
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.17':
-    dependencies:
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/nested-clients': 3.996.7
-      '@aws-sdk/token-providers': 3.1004.0
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@aws-sdk/credential-provider-env': 3.972.18
+      '@aws-sdk/credential-provider-http': 3.972.20
+      '@aws-sdk/credential-provider-ini': 3.972.20
+      '@aws-sdk/credential-provider-process': 3.972.18
+      '@aws-sdk/credential-provider-sso': 3.972.20
+      '@aws-sdk/credential-provider-web-identity': 3.972.20
+      '@aws-sdk/types': 3.973.6
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.17':
+  '@aws-sdk/credential-provider-process@3.972.18':
     dependencies:
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/nested-clients': 3.996.7
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.20':
+    dependencies:
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/token-providers': 3.1009.0
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/eventstream-handler-node@3.972.10':
+  '@aws-sdk/credential-provider-web-identity@3.972.20':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/eventstream-codec': 4.2.11
-      '@smithy/types': 4.13.0
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/eventstream-handler-node@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/eventstream-codec': 4.2.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-eventstream@3.972.7':
+  '@aws-sdk/middleware-eventstream@3.972.8':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
+      '@aws-sdk/types': 3.973.6
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-host-header@3.972.7':
+  '@aws-sdk/middleware-host-header@3.972.8':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
+      '@aws-sdk/types': 3.973.6
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-logger@3.972.7':
+  '@aws-sdk/middleware-logger@3.972.8':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/types': 4.13.0
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-recursion-detection@3.972.7':
+  '@aws-sdk/middleware-recursion-detection@3.972.8':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@aws/lambda-invoke-store': 0.2.3
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
+      '@aws-sdk/types': 3.973.6
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.19':
+  '@aws-sdk/middleware-user-agent@3.972.21':
     dependencies:
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/types': 3.973.5
-      '@aws-sdk/util-endpoints': 3.996.4
-      '@smithy/core': 3.23.9
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
-      '@smithy/util-retry': 4.2.11
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@smithy/core': 3.23.11
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-retry': 4.2.12
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-websocket@3.972.12':
+  '@aws-sdk/middleware-websocket@3.972.13':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@aws-sdk/util-format-url': 3.972.7
-      '@smithy/eventstream-codec': 4.2.11
-      '@smithy/eventstream-serde-browser': 4.2.11
-      '@smithy/fetch-http-handler': 5.3.13
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/signature-v4': 5.3.11
-      '@smithy/types': 4.13.0
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-format-url': 3.972.8
+      '@smithy/eventstream-codec': 4.2.12
+      '@smithy/eventstream-serde-browser': 4.2.12
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-utf8': 4.2.2
@@ -8648,195 +8546,196 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/middleware-host-header': 3.972.7
-      '@aws-sdk/middleware-logger': 3.972.7
-      '@aws-sdk/middleware-recursion-detection': 3.972.7
-      '@aws-sdk/middleware-user-agent': 3.972.19
-      '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/types': 3.973.5
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/middleware-host-header': 3.972.8
+      '@aws-sdk/middleware-logger': 3.972.8
+      '@aws-sdk/middleware-recursion-detection': 3.972.8
+      '@aws-sdk/middleware-user-agent': 3.972.21
+      '@aws-sdk/region-config-resolver': 3.972.8
+      '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.994.0
-      '@aws-sdk/util-user-agent-browser': 3.972.7
-      '@aws-sdk/util-user-agent-node': 3.973.4
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.9
-      '@smithy/fetch-http-handler': 5.3.13
-      '@smithy/hash-node': 4.2.11
-      '@smithy/invalid-dependency': 4.2.11
-      '@smithy/middleware-content-length': 4.2.11
-      '@smithy/middleware-endpoint': 4.4.23
-      '@smithy/middleware-retry': 4.4.40
-      '@smithy/middleware-serde': 4.2.12
-      '@smithy/middleware-stack': 4.2.11
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.14
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.11
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.39
-      '@smithy/util-defaults-mode-node': 4.2.42
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.11
-      '@smithy/util-utf8': 4.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/nested-clients@3.996.7':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/middleware-host-header': 3.972.7
-      '@aws-sdk/middleware-logger': 3.972.7
-      '@aws-sdk/middleware-recursion-detection': 3.972.7
-      '@aws-sdk/middleware-user-agent': 3.972.19
-      '@aws-sdk/region-config-resolver': 3.972.7
-      '@aws-sdk/types': 3.973.5
-      '@aws-sdk/util-endpoints': 3.996.4
-      '@aws-sdk/util-user-agent-browser': 3.972.7
-      '@aws-sdk/util-user-agent-node': 3.973.4
-      '@smithy/config-resolver': 4.4.10
-      '@smithy/core': 3.23.9
-      '@smithy/fetch-http-handler': 5.3.13
-      '@smithy/hash-node': 4.2.11
-      '@smithy/invalid-dependency': 4.2.11
-      '@smithy/middleware-content-length': 4.2.11
-      '@smithy/middleware-endpoint': 4.4.23
-      '@smithy/middleware-retry': 4.4.40
-      '@smithy/middleware-serde': 4.2.12
-      '@smithy/middleware-stack': 4.2.11
-      '@smithy/node-config-provider': 4.3.11
-      '@smithy/node-http-handler': 4.4.14
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.13.0
-      '@smithy/url-parser': 4.2.11
+      '@aws-sdk/util-user-agent-browser': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.973.7
+      '@smithy/config-resolver': 4.4.11
+      '@smithy/core': 3.23.11
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.25
+      '@smithy/middleware-retry': 4.4.42
+      '@smithy/middleware-serde': 4.2.14
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.4.16
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.39
-      '@smithy/util-defaults-mode-node': 4.2.42
-      '@smithy/util-endpoints': 3.3.2
-      '@smithy/util-middleware': 4.2.11
-      '@smithy/util-retry': 4.2.11
+      '@smithy/util-defaults-mode-browser': 4.3.41
+      '@smithy/util-defaults-mode-node': 4.2.44
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/region-config-resolver@3.972.7':
+  '@aws-sdk/nested-clients@3.996.10':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/config-resolver': 4.4.10
-      '@smithy/node-config-provider': 4.3.11
-      '@smithy/types': 4.13.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/middleware-host-header': 3.972.8
+      '@aws-sdk/middleware-logger': 3.972.8
+      '@aws-sdk/middleware-recursion-detection': 3.972.8
+      '@aws-sdk/middleware-user-agent': 3.972.21
+      '@aws-sdk/region-config-resolver': 3.972.8
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@aws-sdk/util-user-agent-browser': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.973.7
+      '@smithy/config-resolver': 4.4.11
+      '@smithy/core': 3.23.11
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.25
+      '@smithy/middleware-retry': 4.4.42
+      '@smithy/middleware-serde': 4.2.14
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.4.16
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.41
+      '@smithy/util-defaults-mode-node': 4.2.44
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/config-resolver': 4.4.11
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.1004.0':
+  '@aws-sdk/token-providers@3.1009.0':
     dependencies:
-      '@aws-sdk/core': 3.973.18
-      '@aws-sdk/nested-clients': 3.996.7
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
   '@aws-sdk/token-providers@3.994.0':
     dependencies:
-      '@aws-sdk/core': 3.973.18
+      '@aws-sdk/core': 3.973.20
       '@aws-sdk/nested-clients': 3.994.0
-      '@aws-sdk/types': 3.973.5
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/types@3.973.5':
+  '@aws-sdk/types@3.973.6':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.994.0':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.11
-      '@smithy/util-endpoints': 3.2.8
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-endpoints': 3.3.3
       tslib: 2.8.1
 
-  '@aws-sdk/util-endpoints@3.996.4':
+  '@aws-sdk/util-endpoints@3.996.5':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/types': 4.13.0
-      '@smithy/url-parser': 4.2.11
-      '@smithy/util-endpoints': 3.3.2
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-endpoints': 3.3.3
       tslib: 2.8.1
 
-  '@aws-sdk/util-format-url@3.972.7':
+  '@aws-sdk/util-format-url@3.972.8':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/querystring-builder': 4.2.11
-      '@smithy/types': 4.13.0
+      '@aws-sdk/types': 3.973.6
+      '@smithy/querystring-builder': 4.2.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-locate-window@3.893.0':
+  '@aws-sdk/util-locate-window@3.965.5':
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-browser@3.972.7':
+  '@aws-sdk/util-user-agent-browser@3.972.8':
     dependencies:
-      '@aws-sdk/types': 3.973.5
-      '@smithy/types': 4.13.0
-      bowser: 2.12.1
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.973.4':
+  '@aws-sdk/util-user-agent-node@3.973.7':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.19
-      '@aws-sdk/types': 3.973.5
-      '@smithy/node-config-provider': 4.3.11
-      '@smithy/types': 4.13.0
+      '@aws-sdk/middleware-user-agent': 3.972.21
+      '@aws-sdk/types': 3.973.6
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.10':
+  '@aws-sdk/xml-builder@3.972.11':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       fast-xml-parser: 5.4.1
       tslib: 2.8.1
 
-  '@aws/lambda-invoke-store@0.2.3': {}
+  '@aws/lambda-invoke-store@0.2.4': {}
 
-  '@babel/code-frame@7.27.1':
+  '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.28.4': {}
+  '@babel/compat-data@7.29.0': {}
 
   '@babel/core@7.26.10':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.26.10)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.26.10
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.10)
+      '@babel/helpers': 7.28.6
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
@@ -8848,35 +8747,15 @@ snapshots:
   '@babel/core@7.26.9':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.26.9)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/core@7.28.4':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-      '@jridgewell/remapping': 2.3.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.9)
+      '@babel/helpers': 7.28.6
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
@@ -8887,144 +8766,135 @@ snapshots:
 
   '@babel/generator@7.26.10':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/generator@7.28.5':
+  '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.25.9':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
-  '@babel/helper-compilation-targets@7.27.2':
+  '@babel/helper-compilation-targets@7.28.6':
     dependencies:
-      '@babel/compat-data': 7.28.4
+      '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.1
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.3(@babel/core@7.26.10)':
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.27.1
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.26.10)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.26.10)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.27.1(@babel/core@7.26.10)':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.26.10)':
+  '@babel/helper-define-polyfill-provider@0.6.7(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
-      resolve: 1.22.10
+      resolve: 1.22.11
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-member-expression-to-functions@7.27.1':
+  '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.27.1':
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.26.10)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.26.9)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
-  '@babel/helper-plugin-utils@7.27.1': {}
+  '@babel/helper-plugin-utils@7.28.6': {}
 
   '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.5
+      '@babel/helper-wrap-function': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.26.10)':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-member-expression-to-functions': 7.27.1
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -9032,55 +8902,55 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helper-wrap-function@7.28.3':
+  '@babel/helper-wrap-function@7.28.6':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helpers@7.28.4':
+  '@babel/helpers@7.28.6':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
-  '@babel/parser@7.28.5':
+  '@babel/parser@7.29.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.26.10)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9088,55 +8958,46 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.10
 
-  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-async-generator-functions@7.26.8(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.26.10)
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.26.10)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-async-to-generator@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
@@ -9144,91 +9005,91 @@ snapshots:
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-block-scoping@7.28.4(@babel/core@7.26.10)':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.26.10)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.4(@babel/core@7.26.10)':
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-globals': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.26.10)
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.26.10)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/template': 7.27.2
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/template': 7.28.6
 
-  '@babel/plugin-transform-destructuring@7.28.0(@babel/core@7.26.10)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-exponentiation-operator@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -9236,115 +9097,115 @@ snapshots:
   '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-logical-assignment-operators@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.26.10)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.26.10)
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.26.10)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.26.10)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-optional-chaining@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -9352,54 +9213,54 @@ snapshots:
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.26.10)':
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-runtime@7.26.10(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.26.10)
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      babel-plugin-polyfill-corejs2: 0.4.16(@babel/core@7.26.10)
       babel-plugin-polyfill-corejs3: 0.11.1(@babel/core@7.26.10)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.26.10)
+      babel-plugin-polyfill-regenerator: 0.6.7(@babel/core@7.26.10)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -9407,12 +9268,12 @@ snapshots:
   '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -9420,112 +9281,112 @@ snapshots:
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.26.10)':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.26.10)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/preset-env@7.26.9(@babel/core@7.26.10)':
     dependencies:
-      '@babel/compat-data': 7.28.4
+      '@babel/compat-data': 7.29.0
       '@babel/core': 7.26.10
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.26.10)
       '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.26.10)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.10)
-      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.26.10)
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-async-generator-functions': 7.26.8(@babel/core@7.26.10)
       '@babel/plugin-transform-async-to-generator': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-block-scoping': 7.28.4(@babel/core@7.26.10)
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.26.10)
-      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.26.10)
-      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.26.10)
-      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.26.10)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.26.10)
       '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-exponentiation-operator': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-logical-assignment-operators': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-modules-systemjs': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.26.10)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.26.10)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.26.10)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.26.10)
-      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-regenerator': 7.28.4(@babel/core@7.26.10)
-      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.26.10)
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.26.10)
-      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.26.10)
       '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.26.10)
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.26.10)
+      babel-plugin-polyfill-corejs2: 0.4.16(@babel/core@7.26.10)
       babel-plugin-polyfill-corejs3: 0.11.1(@babel/core@7.26.10)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.26.10)
-      core-js-compat: 3.46.0
+      babel-plugin-polyfill-regenerator: 0.6.7(@babel/core@7.26.10)
+      core-js-compat: 3.48.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -9533,43 +9394,45 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/types': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/types': 7.29.0
       esutils: 2.0.3
 
   '@babel/runtime@7.26.10':
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@babel/template@7.27.2':
+  '@babel/template@7.28.6':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
 
-  '@babel/traverse@7.28.5':
+  '@babel/traverse@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.28.5':
+  '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@ckeditor/ckeditor-cloud-services-collaboration@53.0.3(@ckeditor/ckeditor5-utils@47.6.0)(ckeditor5@47.6.0)':
+  '@blazediff/core@1.9.1': {}
+
+  '@ckeditor/ckeditor-cloud-services-collaboration@53.0.3(@ckeditor/ckeditor5-utils@47.6.1)(ckeditor5@47.6.1)':
     dependencies:
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       protobufjs: 7.5.4
       socket.io-client: 4.7.0
       socket.io-parser: 4.2.5
@@ -9580,37 +9443,29 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@ckeditor/ckeditor5-adapter-ckfinder@47.2.0':
+  '@ckeditor/ckeditor5-adapter-ckfinder@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-upload': 47.2.0
-      ckeditor5: 47.2.0
-    transitivePeerDependencies:
-      - supports-color
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-adapter-ckfinder@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-upload': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-ai@47.6.0':
+  '@ckeditor/ckeditor5-ai@47.6.1':
     dependencies:
       '@aws-sdk/client-bedrock-runtime': 3.994.0
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
-      '@ckeditor/ckeditor5-collaboration-core': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-markdown-gfm': 47.6.0
-      '@ckeditor/ckeditor5-real-time-collaboration': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      ckeditor5-collaboration: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-collaboration-core': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-markdown-gfm': 47.6.1
+      '@ckeditor/ckeditor5-real-time-collaboration': 47.6.1
+      '@ckeditor/ckeditor5-table': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      ckeditor5-collaboration: 47.6.1
       diff: 8.0.3
       dom-serializer: 2.0.0
       domhandler: 5.0.3
@@ -9625,333 +9480,199 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@ckeditor/ckeditor5-alignment@47.2.0':
+  '@ckeditor/ckeditor5-alignment@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-alignment@47.6.0':
+  '@ckeditor/ckeditor5-autoformat@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-heading': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-autoformat@47.2.0':
+  '@ckeditor/ckeditor5-autosave@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-heading': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-autoformat@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-autosave@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-autosave@47.6.0':
+  '@ckeditor/ckeditor5-basic-styles@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-basic-styles@47.2.0':
+  '@ckeditor/ckeditor5-block-quote@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+
+  '@ckeditor/ckeditor5-bookmark@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-link': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-basic-styles@47.6.0':
+  '@ckeditor/ckeditor5-case-change@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-block-quote@47.2.0':
+  '@ckeditor/ckeditor5-ckbox@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-enter': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-block-quote@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-bookmark@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-link': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-widget': 47.2.0
-      ckeditor5: 47.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-bookmark@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-link': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-case-change@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-ckbox@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-cloud-services': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-image': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-upload': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
       blurhash: 2.0.5
-      ckeditor5: 47.2.0
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-ckbox@47.6.0':
+  '@ckeditor/ckeditor5-ckfinder@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      blurhash: 2.0.5
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-ckfinder@47.2.0':
+  '@ckeditor/ckeditor5-clipboard@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-image': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-ckfinder@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-clipboard@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-widget': 47.2.0
-      es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-clipboard@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
       es-toolkit: 1.39.5
 
-  '@ckeditor/ckeditor5-cloud-services@47.2.0':
+  '@ckeditor/ckeditor5-cloud-services@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+
+  '@ckeditor/ckeditor5-code-block@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-cloud-services@47.6.0':
+  '@ckeditor/ckeditor5-collaboration-core@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-code-block@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-enter': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-code-block@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-collaboration-core@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-comments': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-link': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-track-changes': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
+      '@ckeditor/ckeditor5-comments': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-link': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-track-changes': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
       '@types/luxon': 3.6.2
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.1
       diff: 8.0.3
       luxon: 3.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-comments@47.6.0':
+  '@ckeditor/ckeditor5-comments@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-collaboration-core': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-paragraph': 47.6.0
-      '@ckeditor/ckeditor5-revision-history': 47.6.0
-      '@ckeditor/ckeditor5-select-all': 47.6.0
-      '@ckeditor/ckeditor5-source-editing': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-undo': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
-      ckeditor5-collaboration: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-collaboration-core': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-paragraph': 47.6.1
+      '@ckeditor/ckeditor5-revision-history': 47.6.1
+      '@ckeditor/ckeditor5-select-all': 47.6.1
+      '@ckeditor/ckeditor5-source-editing': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-undo': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
+      ckeditor5-collaboration: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-core@47.2.0':
+  '@ckeditor/ckeditor5-core@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-watchdog': 47.2.0
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-watchdog': 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-core@47.6.0':
+  '@ckeditor/ckeditor5-dev-bump-year@54.5.0':
     dependencies:
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-watchdog': 47.6.0
-      es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
+      glob: 13.0.6
 
-  '@ckeditor/ckeditor5-dev-bump-year@54.3.4':
+  '@ckeditor/ckeditor5-dev-changelog@54.5.0(@babel/core@7.26.10)(@types/node@14.18.63)(typescript@5.5.4)(webpack@5.105.4)':
     dependencies:
-      glob: 13.0.0
-
-  '@ckeditor/ckeditor5-dev-changelog@54.3.4(@babel/core@7.28.4)(@types/node@14.18.63)(typescript@5.5.4)(webpack@5.105.2)':
-    dependencies:
-      '@ckeditor/ckeditor5-dev-utils': 54.3.4(@babel/core@7.28.4)(typescript@5.5.4)(webpack@5.105.2)
+      '@ckeditor/ckeditor5-dev-utils': 54.5.0(@babel/core@7.26.10)(typescript@5.5.4)(webpack@5.105.4)
       date-fns: 4.1.0
-      glob: 13.0.0
+      glob: 13.0.6
       gray-matter: 4.0.3
-      inquirer: 12.10.0(@types/node@14.18.63)
-      semver: 7.7.3
+      inquirer: 12.11.1(@types/node@14.18.63)
+      semver: 7.7.4
       upath: 2.0.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -9964,21 +9685,21 @@ snapshots:
       - uglify-js
       - webpack
 
-  '@ckeditor/ckeditor5-dev-ci@54.3.4':
+  '@ckeditor/ckeditor5-dev-ci@54.5.0':
     dependencies:
-      '@octokit/rest': 22.0.0
+      '@octokit/rest': 22.0.1
       slack-notify: 2.0.7
 
-  '@ckeditor/ckeditor5-dev-release-tools@54.3.4(@babel/core@7.28.4)(@types/node@14.18.63)(typescript@5.5.4)(webpack@5.105.2)':
+  '@ckeditor/ckeditor5-dev-release-tools@54.5.0(@babel/core@7.26.10)(@types/node@14.18.63)(typescript@5.5.4)(webpack@5.105.4)':
     dependencies:
-      '@ckeditor/ckeditor5-dev-utils': 54.3.4(@babel/core@7.28.4)(typescript@5.5.4)(webpack@5.105.2)
-      '@octokit/rest': 22.0.0
+      '@ckeditor/ckeditor5-dev-utils': 54.5.0(@babel/core@7.26.10)(typescript@5.5.4)(webpack@5.105.4)
+      '@octokit/rest': 22.0.1
       cli-columns: 4.0.0
-      glob: 13.0.0
-      inquirer: 12.10.0(@types/node@14.18.63)
-      semver: 7.7.3
+      glob: 13.0.6
+      inquirer: 12.11.1(@types/node@14.18.63)
+      semver: 7.7.4
       shell-escape: 0.2.0
-      simple-git: 3.28.0
+      simple-git: 3.33.0
       upath: 2.0.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -9991,17 +9712,17 @@ snapshots:
       - uglify-js
       - webpack
 
-  '@ckeditor/ckeditor5-dev-translations@54.3.4(@babel/core@7.28.4)(typescript@5.5.4)(webpack@5.105.2)':
+  '@ckeditor/ckeditor5-dev-translations@54.5.0(@babel/core@7.26.10)(typescript@5.5.4)(webpack@5.105.4)':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/traverse': 7.28.5
-      '@ckeditor/ckeditor5-dev-utils': 54.3.4(@babel/core@7.28.4)(typescript@5.5.4)(webpack@5.105.2)
-      glob: 13.0.0
+      '@babel/parser': 7.29.0
+      '@babel/traverse': 7.29.0
+      '@ckeditor/ckeditor5-dev-utils': 54.5.0(@babel/core@7.26.10)(typescript@5.5.4)(webpack@5.105.4)
+      glob: 13.0.6
       plural-forms: 0.5.5
       pofile: 1.1.4
-      rimraf: 6.0.1
+      rimraf: 6.1.3
       upath: 2.0.1
-      webpack-sources: 3.3.3
+      webpack-sources: 3.3.4
     transitivePeerDependencies:
       - '@babel/core'
       - '@rspack/core'
@@ -10012,32 +9733,32 @@ snapshots:
       - uglify-js
       - webpack
 
-  '@ckeditor/ckeditor5-dev-utils@54.3.4(@babel/core@7.28.4)(typescript@5.5.4)(webpack@5.105.2)':
+  '@ckeditor/ckeditor5-dev-utils@54.5.0(@babel/core@7.26.10)(typescript@5.5.4)(webpack@5.105.4)':
     dependencies:
-      '@ckeditor/ckeditor5-dev-translations': 54.3.4(@babel/core@7.28.4)(typescript@5.5.4)(webpack@5.105.2)
+      '@ckeditor/ckeditor5-dev-translations': 54.5.0(@babel/core@7.26.10)(typescript@5.5.4)(webpack@5.105.4)
       '@types/postcss-import': 14.0.3
       '@types/through2': 2.0.41
-      babel-loader: 10.0.0(@babel/core@7.28.4)(webpack@5.105.2)
+      babel-loader: 10.1.1(@babel/core@7.26.10)(webpack@5.105.4)
       cli-cursor: 5.0.0
-      cli-spinners: 3.3.0
-      css-loader: 7.1.2(webpack@5.105.2)
-      cssnano: 7.1.1(postcss@8.5.6)
-      esbuild-loader: 4.4.0(webpack@5.105.2)
-      glob: 13.0.0
+      cli-spinners: 3.4.0
+      css-loader: 7.1.4(webpack@5.105.4)
+      cssnano: 7.1.3(postcss@8.5.8)
+      esbuild-loader: 4.4.2(webpack@5.105.4)
+      glob: 13.0.6
       is-interactive: 2.0.0
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.2)
-      mocha: 11.7.4
-      pacote: 21.0.3
-      postcss: 8.5.6
-      postcss-import: 16.1.1(postcss@8.5.6)
-      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.5.4)(webpack@5.105.2)
-      postcss-mixins: 11.0.3(postcss@8.5.6)
-      postcss-nesting: 13.0.2(postcss@8.5.6)
-      raw-loader: 4.0.2(webpack@5.105.2)
+      mini-css-extract-plugin: 2.10.1(webpack@5.105.4)
+      mocha: 11.7.5
+      pacote: 21.5.0
+      postcss: 8.5.8
+      postcss-import: 16.1.1(postcss@8.5.8)
+      postcss-loader: 8.2.1(postcss@8.5.8)(typescript@5.5.4)(webpack@5.105.4)
+      postcss-mixins: 11.0.3(postcss@8.5.8)
+      postcss-nesting: 13.0.2(postcss@8.5.8)
+      raw-loader: 4.0.2(webpack@5.105.4)
       shelljs: 0.10.0
-      simple-git: 3.28.0
-      style-loader: 4.0.0(webpack@5.105.2)
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.4)(webpack@5.105.2)
+      simple-git: 3.33.0
+      style-loader: 4.0.0(webpack@5.105.4)
+      terser-webpack-plugin: 5.4.0(esbuild@0.25.4)(webpack@5.105.4)
       through2: 4.0.2
       upath: 2.0.1
     transitivePeerDependencies:
@@ -10050,642 +9771,388 @@ snapshots:
       - uglify-js
       - webpack
 
-  '@ckeditor/ckeditor5-document-outline@47.6.0':
+  '@ckeditor/ckeditor5-document-outline@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-heading': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
 
-  '@ckeditor/ckeditor5-easy-image@47.2.0':
+  '@ckeditor/ckeditor5-easy-image@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-cloud-services': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-upload': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-easy-image@47.6.0':
+  '@ckeditor/ckeditor5-editor-balloon@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-editor-balloon@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-      es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-editor-balloon@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
 
-  '@ckeditor/ckeditor5-editor-classic@47.2.0':
+  '@ckeditor/ckeditor5-editor-classic@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-      es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-editor-classic@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
 
-  '@ckeditor/ckeditor5-editor-decoupled@47.2.0':
+  '@ckeditor/ckeditor5-editor-decoupled@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-editor-inline@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-editor-multi-root@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-editor-decoupled@47.6.0':
+  '@ckeditor/ckeditor5-email@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-editor-inline@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-      es-toolkit: 1.39.5
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-export-inline-styles': 47.6.1
+      '@ckeditor/ckeditor5-font': 47.6.1
+      '@ckeditor/ckeditor5-html-support': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-table': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-editor-inline@47.6.0':
+  '@ckeditor/ckeditor5-emoji@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-editor-multi-root@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-      es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-editor-multi-root@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-email@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-export-inline-styles': 47.6.0
-      '@ckeditor/ckeditor5-font': 47.6.0
-      '@ckeditor/ckeditor5-html-support': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-emoji@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-mention': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-mention': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
       fuzzysort: 3.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-emoji@47.6.0':
+  '@ckeditor/ckeditor5-engine@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-mention': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.1
       es-toolkit: 1.39.5
-      fuzzysort: 3.1.0
+
+  '@ckeditor/ckeditor5-enter@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+
+  '@ckeditor/ckeditor5-essentials@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-select-all': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-undo': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-engine@47.2.0':
+  '@ckeditor/ckeditor5-export-inline-styles@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-engine@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-enter@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-
-  '@ckeditor/ckeditor5-enter@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-
-  '@ckeditor/ckeditor5-essentials@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-enter': 47.2.0
-      '@ckeditor/ckeditor5-select-all': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-undo': 47.2.0
-      ckeditor5: 47.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-essentials@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-select-all': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-undo': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-export-inline-styles@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       specificity: 0.4.1
 
-  '@ckeditor/ckeditor5-export-pdf@47.6.0':
+  '@ckeditor/ckeditor5-export-pdf@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-merge-fields': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-merge-fields': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-export-word@47.6.0':
+  '@ckeditor/ckeditor5-export-word@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
-      '@ckeditor/ckeditor5-collaboration-core': 47.6.0
-      '@ckeditor/ckeditor5-comments': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-merge-fields': 47.6.0
-      '@ckeditor/ckeditor5-track-changes': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-collaboration-core': 47.6.1
+      '@ckeditor/ckeditor5-comments': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-merge-fields': 47.6.1
+      '@ckeditor/ckeditor5-track-changes': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-find-and-replace@47.2.0':
+  '@ckeditor/ckeditor5-find-and-replace@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-font@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-footnotes@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
+
+  '@ckeditor/ckeditor5-format-painter@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+
+  '@ckeditor/ckeditor5-fullscreen@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-editor-classic': 47.6.1
+      '@ckeditor/ckeditor5-editor-decoupled': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-heading@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-paragraph': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-highlight@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-horizontal-line@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
+
+  '@ckeditor/ckeditor5-html-embed@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-html-support@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-heading': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-remove-format': 47.6.1
+      '@ckeditor/ckeditor5-table': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-find-and-replace@47.6.0':
+  '@ckeditor/ckeditor5-icons@47.6.1': {}
+
+  '@ckeditor/ckeditor5-image@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-font@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-font@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-footnotes@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-format-painter@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-fullscreen@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-editor-classic': 47.2.0
-      '@ckeditor/ckeditor5-editor-decoupled': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-fullscreen@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-classic': 47.6.0
-      '@ckeditor/ckeditor5-editor-decoupled': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-heading@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-paragraph': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-heading@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-paragraph': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-highlight@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-highlight@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-horizontal-line@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-widget': 47.2.0
-      ckeditor5: 47.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-horizontal-line@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-html-embed@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-widget': 47.2.0
-      ckeditor5: 47.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-html-embed@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-html-support@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-enter': 47.2.0
-      '@ckeditor/ckeditor5-heading': 47.2.0
-      '@ckeditor/ckeditor5-image': 47.2.0
-      '@ckeditor/ckeditor5-list': 47.2.0
-      '@ckeditor/ckeditor5-remove-format': 47.2.0
-      '@ckeditor/ckeditor5-table': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-widget': 47.2.0
-      ckeditor5: 47.2.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-html-support@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-remove-format': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-icons@47.2.0': {}
-
-  '@ckeditor/ckeditor5-icons@47.6.0': {}
-
-  '@ckeditor/ckeditor5-image@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-undo': 47.2.0
-      '@ckeditor/ckeditor5-upload': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-widget': 47.2.0
-      ckeditor5: 47.2.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-image@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-undo': 47.6.0
-      '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-undo': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-import-word@47.6.0':
+  '@ckeditor/ckeditor5-import-word@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-merge-fields': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-merge-fields': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-indent@47.2.0':
+  '@ckeditor/ckeditor5-indent@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-heading': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-list': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-indent@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-heading': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-integrations-common@2.2.3(ckeditor5@47.2.0)':
+  '@ckeditor/ckeditor5-integrations-common@2.2.4(ckeditor5@47.6.1)':
     dependencies:
-      ckeditor5: 47.2.0
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-integrations-common@2.2.3(ckeditor5@47.6.0)':
+  '@ckeditor/ckeditor5-language@47.6.1':
     dependencies:
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-language@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-language@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-line-height@47.6.0':
+  '@ckeditor/ckeditor5-line-height@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-link@47.2.0':
+  '@ckeditor/ckeditor5-link@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-image': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-widget': 47.2.0
-      ckeditor5: 47.2.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-link@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-list-multi-level@47.6.0':
+  '@ckeditor/ckeditor5-list-multi-level@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-list@47.2.0':
+  '@ckeditor/ckeditor5-list@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-enter': 47.2.0
-      '@ckeditor/ckeditor5-font': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-list@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-font': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-font': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-markdown-gfm@47.2.0':
+  '@ckeditor/ckeditor5-markdown-gfm@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
       '@types/hast': 3.0.4
-      ckeditor5: 47.2.0
+      ckeditor5: 47.6.1
       hast-util-from-dom: 5.0.1
       hast-util-to-html: 9.0.5
       hast-util-to-mdast: 10.1.2
@@ -10703,479 +10170,315 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-markdown-gfm@47.6.0':
+  '@ckeditor/ckeditor5-media-embed@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@types/hast': 3.0.4
-      ckeditor5: 47.6.0
-      hast-util-from-dom: 5.0.1
-      hast-util-to-html: 9.0.5
-      hast-util-to-mdast: 10.1.2
-      hastscript: 9.0.1
-      rehype-dom-parse: 5.0.2
-      rehype-dom-stringify: 4.0.2
-      rehype-remark: 10.0.1
-      remark-breaks: 4.0.0
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      remark-stringify: 11.0.0
-      unified: 11.0.5
-      unist-util-visit: 5.0.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-undo': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-media-embed@47.2.0':
+  '@ckeditor/ckeditor5-mention@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-undo': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-widget': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-media-embed@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-undo': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-mention@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-mention@47.6.0':
+  '@ckeditor/ckeditor5-merge-fields@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-mention': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-minimap@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-merge-fields@47.6.0':
+  '@ckeditor/ckeditor5-operations-compressor@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-mention': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-minimap@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-minimap@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-operations-compressor@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
       protobufjs: 7.5.4
 
-  '@ckeditor/ckeditor5-page-break@47.2.0':
+  '@ckeditor/ckeditor5-page-break@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-widget': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-page-break@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-pagination@47.6.0':
+  '@ckeditor/ckeditor5-pagination@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
 
-  '@ckeditor/ckeditor5-paragraph@47.2.0':
+  '@ckeditor/ckeditor5-paragraph@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
 
-  '@ckeditor/ckeditor5-paragraph@47.6.0':
+  '@ckeditor/ckeditor5-paste-from-office-enhanced@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-paste-from-office': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-paste-from-office-enhanced@47.6.0':
+  '@ckeditor/ckeditor5-paste-from-office@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-paste-from-office': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-paste-from-office@47.2.0':
+  '@ckeditor/ckeditor5-real-time-collaboration@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-paste-from-office@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-real-time-collaboration@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor-cloud-services-collaboration': 53.0.3(@ckeditor/ckeditor5-utils@47.6.0)(ckeditor5@47.6.0)
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
-      '@ckeditor/ckeditor5-comments': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-operations-compressor': 47.6.0
-      '@ckeditor/ckeditor5-revision-history': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-track-changes': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      ckeditor5-collaboration: 47.6.0
+      '@ckeditor/ckeditor-cloud-services-collaboration': 53.0.3(@ckeditor/ckeditor5-utils@47.6.1)(ckeditor5@47.6.1)
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-comments': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-operations-compressor': 47.6.1
+      '@ckeditor/ckeditor5-revision-history': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-track-changes': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      ckeditor5-collaboration: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@ckeditor/ckeditor5-remove-format@47.2.0':
+  '@ckeditor/ckeditor5-remove-format@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-remove-format@47.6.0':
+  '@ckeditor/ckeditor5-restricted-editing@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-restricted-editing@47.2.0':
+  '@ckeditor/ckeditor5-revision-history@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-restricted-editing@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-revision-history@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-autosave': 47.6.0
-      '@ckeditor/ckeditor5-collaboration-core': 47.6.0
-      '@ckeditor/ckeditor5-comments': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-classic': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-autosave': 47.6.1
+      '@ckeditor/ckeditor5-collaboration-core': 47.6.1
+      '@ckeditor/ckeditor5-comments': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-editor-classic': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
       '@types/luxon': 3.6.2
-      ckeditor5: 47.6.0
-      ckeditor5-collaboration: 47.6.0
+      ckeditor5: 47.6.1
+      ckeditor5-collaboration: 47.6.1
       es-toolkit: 1.39.5
       luxon: 3.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-select-all@47.2.0':
+  '@ckeditor/ckeditor5-select-all@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
 
-  '@ckeditor/ckeditor5-select-all@47.6.0':
+  '@ckeditor/ckeditor5-show-blocks@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-
-  '@ckeditor/ckeditor5-show-blocks@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-show-blocks@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-slash-command@47.6.0':
+  '@ckeditor/ckeditor5-slash-command@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-mention': 47.6.0
-      '@ckeditor/ckeditor5-style': 47.6.0
-      '@ckeditor/ckeditor5-template': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-heading': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-mention': 47.6.1
+      '@ckeditor/ckeditor5-style': 47.6.1
+      '@ckeditor/ckeditor5-template': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-source-editing-enhanced@47.6.0':
+  '@ckeditor/ckeditor5-source-editing-enhanced@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@codemirror/autocomplete': 6.19.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@codemirror/autocomplete': 6.20.1
       '@codemirror/commands': 6.8.1
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-markdown': 6.3.2
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
       '@codemirror/theme-one-dark': 6.1.3
-      '@codemirror/view': 6.38.6
-      ckeditor5: 47.6.0
+      '@codemirror/view': 6.40.0
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-source-editing@47.2.0':
+  '@ckeditor/ckeditor5-source-editing@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-theme-lark': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-source-editing@47.6.0':
+  '@ckeditor/ckeditor5-special-characters@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-special-characters@47.2.0':
+  '@ckeditor/ckeditor5-style@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-
-  '@ckeditor/ckeditor5-special-characters@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-style@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-html-support': 47.2.0
-      '@ckeditor/ckeditor5-list': 47.2.0
-      '@ckeditor/ckeditor5-table': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-style@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-html-support': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-html-support': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-table': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-table@47.2.0':
+  '@ckeditor/ckeditor5-table@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-widget': 47.2.0
-      ckeditor5: 47.2.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-table@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-template@47.6.0':
+  '@ckeditor/ckeditor5-template@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-theme-lark@47.2.0':
+  '@ckeditor/ckeditor5-theme-lark@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-ui': 47.2.0
+      '@ckeditor/ckeditor5-ui': 47.6.1
 
-  '@ckeditor/ckeditor5-theme-lark@47.6.0':
+  '@ckeditor/ckeditor5-track-changes@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-ui': 47.6.0
-
-  '@ckeditor/ckeditor5-track-changes@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-code-block': 47.6.0
-      '@ckeditor/ckeditor5-comments': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-find-and-replace': 47.6.0
-      '@ckeditor/ckeditor5-font': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-highlight': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-link': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-media-embed': 47.6.0
-      '@ckeditor/ckeditor5-merge-fields': 47.6.0
-      '@ckeditor/ckeditor5-restricted-editing': 47.6.0
-      '@ckeditor/ckeditor5-style': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      ckeditor5-collaboration: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-code-block': 47.6.1
+      '@ckeditor/ckeditor5-comments': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-find-and-replace': 47.6.1
+      '@ckeditor/ckeditor5-font': 47.6.1
+      '@ckeditor/ckeditor5-heading': 47.6.1
+      '@ckeditor/ckeditor5-highlight': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-link': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-media-embed': 47.6.1
+      '@ckeditor/ckeditor5-merge-fields': 47.6.1
+      '@ckeditor/ckeditor5-restricted-editing': 47.6.1
+      '@ckeditor/ckeditor5-style': 47.6.1
+      '@ckeditor/ckeditor5-table': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      ckeditor5-collaboration: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-typing@47.2.0':
+  '@ckeditor/ckeditor5-typing@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
       es-toolkit: 1.39.5
 
-  '@ckeditor/ckeditor5-typing@47.6.0':
+  '@ckeditor/ckeditor5-ui@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-ui@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
       '@types/color-convert': 2.0.4
       color-convert: 3.1.0
       color-parse: 2.0.2
@@ -11184,236 +10487,174 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-ui@47.6.0':
+  '@ckeditor/ckeditor5-undo@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@types/color-convert': 2.0.4
-      color-convert: 3.1.0
-      color-parse: 2.0.2
-      es-toolkit: 1.39.5
-      vanilla-colorful: 0.7.2
-    transitivePeerDependencies:
-      - supports-color
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
 
-  '@ckeditor/ckeditor5-undo@47.2.0':
+  '@ckeditor/ckeditor5-upload@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
 
-  '@ckeditor/ckeditor5-undo@47.6.0':
+  '@ckeditor/ckeditor5-uploadcare@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-
-  '@ckeditor/ckeditor5-upload@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-
-  '@ckeditor/ckeditor5-upload@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-uploadcare@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
       '@uploadcare/file-uploader': 1.24.5
       '@uploadcare/upload-client': 6.14.3
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@ckeditor/ckeditor5-utils@47.2.0':
+  '@ckeditor/ckeditor5-utils@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-ui': 47.2.0
+      '@ckeditor/ckeditor5-ui': 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-utils@47.6.0':
+  '@ckeditor/ckeditor5-watchdog@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-ui': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-watchdog@47.2.0':
+  '@ckeditor/ckeditor5-widget@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-watchdog@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-widget@47.2.0':
+  '@ckeditor/ckeditor5-word-count@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-enter': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-widget@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-word-count@47.2.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      ckeditor5: 47.2.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-word-count@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@codemirror/autocomplete@6.19.0':
+  '@codemirror/autocomplete@6.20.1':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.6
-      '@lezer/common': 1.2.3
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
 
   '@codemirror/commands@6.8.1':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.6
-      '@lezer/common': 1.2.3
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
 
   '@codemirror/lang-css@6.3.1':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@lezer/common': 1.2.3
-      '@lezer/css': 1.3.0
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.1
+      '@lezer/css': 1.3.1
 
   '@codemirror/lang-html@6.4.11':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
+      '@codemirror/autocomplete': 6.20.1
       '@codemirror/lang-css': 6.3.1
-      '@codemirror/lang-javascript': 6.2.4
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.6
-      '@lezer/common': 1.2.3
-      '@lezer/css': 1.3.0
-      '@lezer/html': 1.3.12
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/css': 1.3.1
+      '@lezer/html': 1.3.13
 
-  '@codemirror/lang-javascript@6.2.4':
+  '@codemirror/lang-javascript@6.2.5':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/language': 6.11.3
-      '@codemirror/lint': 6.9.0
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.6
-      '@lezer/common': 1.2.3
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
       '@lezer/javascript': 1.5.4
 
   '@codemirror/lang-markdown@6.3.2':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
+      '@codemirror/autocomplete': 6.20.1
       '@codemirror/lang-html': 6.4.11
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.6
-      '@lezer/common': 1.2.3
-      '@lezer/markdown': 1.4.3
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/markdown': 1.6.3
 
-  '@codemirror/language@6.11.3':
+  '@codemirror/language@6.12.2':
     dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.6
-      '@lezer/common': 1.2.3
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
-      style-mod: 4.1.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+      style-mod: 4.1.3
 
-  '@codemirror/lint@6.9.0':
+  '@codemirror/lint@6.9.5':
     dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.6
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
       crelt: 1.0.6
 
-  '@codemirror/state@6.5.2':
+  '@codemirror/state@6.6.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
   '@codemirror/theme-one-dark@6.1.3':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.6
-      '@lezer/highlight': 1.2.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/highlight': 1.2.3
 
-  '@codemirror/view@6.38.6':
+  '@codemirror/view@6.40.0':
     dependencies:
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.6.0
       crelt: 1.0.6
-      style-mod: 4.1.2
+      style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
   '@colors/colors@1.5.0':
     optional: true
 
-  '@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.0)':
+  '@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.1)':
     dependencies:
-      postcss-selector-parser: 7.1.0
+      postcss-selector-parser: 7.1.1
 
-  '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.0)':
+  '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.1)':
     dependencies:
-      postcss-selector-parser: 7.1.0
+      postcss-selector-parser: 7.1.1
 
-  '@cypress/request@3.0.9':
+  '@cypress/request@3.0.10':
     dependencies:
       aws-sign2: 0.7.0
       aws4: 1.13.2
@@ -11421,14 +10662,14 @@ snapshots:
       combined-stream: 1.0.8
       extend: 3.0.2
       forever-agent: 0.6.1
-      form-data: 4.0.4
+      form-data: 4.0.5
       http-signature: 1.4.0
       is-typedarray: 1.0.0
       isstream: 0.1.2
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.15.0
+      qs: 6.14.2
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
@@ -11448,182 +10689,260 @@ snapshots:
   '@es-joy/jsdoccomment@0.50.2':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.46.1
+      '@typescript-eslint/types': 8.57.0
       comment-parser: 1.4.1
-      esquery: 1.6.0
+      esquery: 1.7.0
       jsdoc-type-pratt-parser: 4.1.0
 
-  '@esbuild/aix-ppc64@0.25.10':
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.25.4':
     optional: true
 
-  '@esbuild/android-arm64@0.25.10':
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.25.4':
     optional: true
 
-  '@esbuild/android-arm@0.25.10':
+  '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.25.4':
     optional: true
 
-  '@esbuild/android-x64@0.25.10':
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.25.4':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.10':
+  '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.4':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.10':
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.25.4':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.10':
+  '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.4':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.10':
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.4':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.10':
+  '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.25.4':
     optional: true
 
-  '@esbuild/linux-arm@0.25.10':
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.25.4':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.10':
+  '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.25.4':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.10':
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.25.4':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.10':
+  '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.4':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.10':
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.4':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.10':
+  '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.4':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.10':
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.25.4':
     optional: true
 
-  '@esbuild/linux-x64@0.25.10':
+  '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
   '@esbuild/linux-x64@0.25.4':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.10':
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.4':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.10':
+  '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.4':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.10':
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.4':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.10':
+  '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.4':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.10':
+  '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.10':
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.25.4':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.10':
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.25.4':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.10':
+  '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.25.4':
     optional: true
 
-  '@esbuild/win32-x64@0.25.10':
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.25.4':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0(jiti@2.6.1))':
+  '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
-      eslint: 9.38.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.12.1': {}
+  '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.1':
+  '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 3.1.3
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.4.1':
+  '@eslint/config-helpers@0.4.2':
     dependencies:
-      '@eslint/core': 0.16.0
+      '@eslint/core': 0.17.0
 
   '@eslint/core@0.14.0':
     dependencies:
@@ -11633,11 +10952,11 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/core@0.16.0':
+  '@eslint/core@0.17.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1':
+  '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -11646,19 +10965,19 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.3
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.38.0': {}
+  '@eslint/js@9.39.4': {}
 
   '@eslint/markdown@6.6.0':
     dependencies:
       '@eslint/core': 0.14.0
       '@eslint/plugin-kit': 0.3.5
       github-slugger: 2.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-frontmatter: 2.0.1
       mdast-util-gfm: 3.1.0
       micromark-extension-frontmatter: 2.0.0
@@ -11673,10 +10992,14 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
-  '@eslint/plugin-kit@0.4.0':
+  '@eslint/plugin-kit@0.4.1':
     dependencies:
-      '@eslint/core': 0.16.0
+      '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@gar/promise-retry@1.0.2':
+    dependencies:
+      retry: 0.13.1
 
   '@hapi/address@5.1.1':
     dependencies:
@@ -11688,7 +11011,7 @@ snapshots:
 
   '@hapi/pinpoint@2.0.1': {}
 
-  '@hapi/tlds@1.1.3': {}
+  '@hapi/tlds@1.1.6': {}
 
   '@hapi/topo@6.0.2':
     dependencies:
@@ -11705,37 +11028,37 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/ansi@1.0.1': {}
+  '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.0(@types/node@14.18.63)':
+  '@inquirer/checkbox@4.3.2(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/ansi': 1.0.1
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/figures': 1.0.14
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 14.18.63
 
-  '@inquirer/confirm@5.1.19(@types/node@14.18.63)':
+  '@inquirer/confirm@5.1.21(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
     optionalDependencies:
       '@types/node': 14.18.63
 
   '@inquirer/confirm@5.1.6(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
     optionalDependencies:
       '@types/node': 14.18.63
 
-  '@inquirer/core@10.3.0(@types/node@14.18.63)':
+  '@inquirer/core@10.3.2(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/ansi': 1.0.1
-      '@inquirer/figures': 1.0.14
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
@@ -11744,106 +11067,106 @@ snapshots:
     optionalDependencies:
       '@types/node': 14.18.63
 
-  '@inquirer/editor@4.2.21(@types/node@14.18.63)':
+  '@inquirer/editor@4.2.23(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/external-editor': 1.0.2(@types/node@14.18.63)
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/external-editor': 1.0.3(@types/node@14.18.63)
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
     optionalDependencies:
       '@types/node': 14.18.63
 
-  '@inquirer/expand@4.0.21(@types/node@14.18.63)':
+  '@inquirer/expand@4.0.23(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 14.18.63
 
-  '@inquirer/external-editor@1.0.2(@types/node@14.18.63)':
+  '@inquirer/external-editor@1.0.3(@types/node@14.18.63)':
     dependencies:
-      chardet: 2.1.0
-      iconv-lite: 0.7.0
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 14.18.63
 
-  '@inquirer/figures@1.0.14': {}
+  '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.2.5(@types/node@14.18.63)':
+  '@inquirer/input@4.3.1(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
     optionalDependencies:
       '@types/node': 14.18.63
 
-  '@inquirer/number@3.0.21(@types/node@14.18.63)':
+  '@inquirer/number@3.0.23(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
     optionalDependencies:
       '@types/node': 14.18.63
 
-  '@inquirer/password@4.0.21(@types/node@14.18.63)':
+  '@inquirer/password@4.0.23(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/ansi': 1.0.1
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
+    optionalDependencies:
+      '@types/node': 14.18.63
+
+  '@inquirer/prompts@7.10.1(@types/node@14.18.63)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@14.18.63)
+      '@inquirer/confirm': 5.1.21(@types/node@14.18.63)
+      '@inquirer/editor': 4.2.23(@types/node@14.18.63)
+      '@inquirer/expand': 4.0.23(@types/node@14.18.63)
+      '@inquirer/input': 4.3.1(@types/node@14.18.63)
+      '@inquirer/number': 3.0.23(@types/node@14.18.63)
+      '@inquirer/password': 4.0.23(@types/node@14.18.63)
+      '@inquirer/rawlist': 4.1.11(@types/node@14.18.63)
+      '@inquirer/search': 3.2.2(@types/node@14.18.63)
+      '@inquirer/select': 4.4.2(@types/node@14.18.63)
     optionalDependencies:
       '@types/node': 14.18.63
 
   '@inquirer/prompts@7.3.2(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/checkbox': 4.3.0(@types/node@14.18.63)
-      '@inquirer/confirm': 5.1.19(@types/node@14.18.63)
-      '@inquirer/editor': 4.2.21(@types/node@14.18.63)
-      '@inquirer/expand': 4.0.21(@types/node@14.18.63)
-      '@inquirer/input': 4.2.5(@types/node@14.18.63)
-      '@inquirer/number': 3.0.21(@types/node@14.18.63)
-      '@inquirer/password': 4.0.21(@types/node@14.18.63)
-      '@inquirer/rawlist': 4.1.9(@types/node@14.18.63)
-      '@inquirer/search': 3.2.0(@types/node@14.18.63)
-      '@inquirer/select': 4.4.0(@types/node@14.18.63)
+      '@inquirer/checkbox': 4.3.2(@types/node@14.18.63)
+      '@inquirer/confirm': 5.1.21(@types/node@14.18.63)
+      '@inquirer/editor': 4.2.23(@types/node@14.18.63)
+      '@inquirer/expand': 4.0.23(@types/node@14.18.63)
+      '@inquirer/input': 4.3.1(@types/node@14.18.63)
+      '@inquirer/number': 3.0.23(@types/node@14.18.63)
+      '@inquirer/password': 4.0.23(@types/node@14.18.63)
+      '@inquirer/rawlist': 4.1.11(@types/node@14.18.63)
+      '@inquirer/search': 3.2.2(@types/node@14.18.63)
+      '@inquirer/select': 4.4.2(@types/node@14.18.63)
     optionalDependencies:
       '@types/node': 14.18.63
 
-  '@inquirer/prompts@7.9.0(@types/node@14.18.63)':
+  '@inquirer/rawlist@4.1.11(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/checkbox': 4.3.0(@types/node@14.18.63)
-      '@inquirer/confirm': 5.1.19(@types/node@14.18.63)
-      '@inquirer/editor': 4.2.21(@types/node@14.18.63)
-      '@inquirer/expand': 4.0.21(@types/node@14.18.63)
-      '@inquirer/input': 4.2.5(@types/node@14.18.63)
-      '@inquirer/number': 3.0.21(@types/node@14.18.63)
-      '@inquirer/password': 4.0.21(@types/node@14.18.63)
-      '@inquirer/rawlist': 4.1.9(@types/node@14.18.63)
-      '@inquirer/search': 3.2.0(@types/node@14.18.63)
-      '@inquirer/select': 4.4.0(@types/node@14.18.63)
-    optionalDependencies:
-      '@types/node': 14.18.63
-
-  '@inquirer/rawlist@4.1.9(@types/node@14.18.63)':
-    dependencies:
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 14.18.63
 
-  '@inquirer/search@3.2.0(@types/node@14.18.63)':
+  '@inquirer/search@3.2.2(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/figures': 1.0.14
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 14.18.63
 
-  '@inquirer/select@4.4.0(@types/node@14.18.63)':
+  '@inquirer/select@4.4.2(@types/node@14.18.63)':
     dependencies:
-      '@inquirer/ansi': 1.0.1
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/figures': 1.0.14
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 14.18.63
@@ -11852,7 +11175,7 @@ snapshots:
     dependencies:
       mute-stream: 1.0.0
 
-  '@inquirer/type@3.0.9(@types/node@14.18.63)':
+  '@inquirer/type@3.0.10(@types/node@14.18.63)':
     optionalDependencies:
       '@types/node': 14.18.63
 
@@ -11860,25 +11183,20 @@ snapshots:
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@istanbuljs/schema@0.1.3': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
-
-  '@jridgewell/remapping@2.3.5':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -11899,12 +11217,80 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@jsonjoy.com/base64@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
   '@jsonjoy.com/buffers@1.2.1(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/buffers@17.67.0(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
 
   '@jsonjoy.com/codegen@1.0.0(tslib@2.8.1)':
     dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/codegen@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-core@4.56.11(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
+      thingies: 2.5.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-fsa@4.56.11(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
+      thingies: 2.5.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-builtins@4.56.11(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-to-fsa@4.56.11(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-fsa': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-utils@4.56.11(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node@4.56.11(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.56.11(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.5.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-print@4.56.11(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-snapshot@4.56.11(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/json-pack': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
   '@jsonjoy.com/json-pack@1.21.0(tslib@2.8.1)':
@@ -11919,16 +11305,39 @@ snapshots:
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  '@jsonjoy.com/json-pack@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/json-pointer': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 2.5.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
   '@jsonjoy.com/json-pointer@1.0.2(tslib@2.8.1)':
     dependencies:
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
       '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  '@jsonjoy.com/json-pointer@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
+
   '@jsonjoy.com/util@1.9.0(tslib@2.8.1)':
     dependencies:
       '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
   '@kwsites/file-exists@1.1.1':
@@ -11941,38 +11350,38 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
-  '@lezer/common@1.2.3': {}
+  '@lezer/common@1.5.1': {}
 
-  '@lezer/css@1.3.0':
+  '@lezer/css@1.3.1':
     dependencies:
-      '@lezer/common': 1.2.3
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
 
-  '@lezer/highlight@1.2.1':
+  '@lezer/highlight@1.2.3':
     dependencies:
-      '@lezer/common': 1.2.3
+      '@lezer/common': 1.5.1
 
-  '@lezer/html@1.3.12':
+  '@lezer/html@1.3.13':
     dependencies:
-      '@lezer/common': 1.2.3
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
 
   '@lezer/javascript@1.5.4':
     dependencies:
-      '@lezer/common': 1.2.3
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
 
-  '@lezer/lr@1.4.2':
+  '@lezer/lr@1.4.8':
     dependencies:
-      '@lezer/common': 1.2.3
+      '@lezer/common': 1.5.1
 
-  '@lezer/markdown@1.4.3':
+  '@lezer/markdown@1.6.3':
     dependencies:
-      '@lezer/common': 1.2.3
-      '@lezer/highlight': 1.2.1
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
 
   '@listr2/prompt-adapter-inquirer@2.0.18(@inquirer/prompts@7.3.2(@types/node@14.18.63))':
     dependencies:
@@ -12089,11 +11498,11 @@ snapshots:
       '@napi-rs/nice-win32-x64-msvc': 1.1.1
     optional: true
 
-  '@ngtools/webpack@19.2.19(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(typescript@5.5.4)(webpack@5.105.2)':
+  '@ngtools/webpack@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(typescript@5.5.4)(webpack@5.105.4)':
     dependencies:
-      '@angular/compiler-cli': 19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4)
+      '@angular/compiler-cli': 19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4)
       typescript: 5.5.4
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -12105,7 +11514,7 @@ snapshots:
   '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.19.1
+      fastq: 1.20.1
 
   '@npmcli/agent@3.0.0':
     dependencies:
@@ -12122,14 +11531,18 @@ snapshots:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      lru-cache: 11.2.2
+      lru-cache: 11.2.7
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
 
   '@npmcli/fs@4.0.0':
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
+
+  '@npmcli/fs@5.0.0':
+    dependencies:
+      semver: 7.7.4
 
   '@npmcli/git@6.0.3':
     dependencies:
@@ -12139,26 +11552,33 @@ snapshots:
       npm-pick-manifest: 10.0.0
       proc-log: 5.0.0
       promise-retry: 2.0.1
-      semver: 7.7.3
+      semver: 7.7.4
       which: 5.0.0
 
-  '@npmcli/git@7.0.0':
+  '@npmcli/git@7.0.2':
     dependencies:
-      '@npmcli/promise-spawn': 8.0.3
-      ini: 5.0.0
-      lru-cache: 11.2.2
-      npm-pick-manifest: 11.0.1
-      proc-log: 5.0.0
-      promise-retry: 2.0.1
-      semver: 7.7.3
-      which: 5.0.0
+      '@gar/promise-retry': 1.0.2
+      '@npmcli/promise-spawn': 9.0.1
+      ini: 6.0.0
+      lru-cache: 11.2.7
+      npm-pick-manifest: 11.0.3
+      proc-log: 6.1.0
+      semver: 7.7.4
+      which: 6.0.1
 
   '@npmcli/installed-package-contents@3.0.0':
     dependencies:
       npm-bundled: 4.0.0
       npm-normalize-package-bin: 4.0.0
 
+  '@npmcli/installed-package-contents@4.0.0':
+    dependencies:
+      npm-bundled: 5.0.0
+      npm-normalize-package-bin: 5.0.0
+
   '@npmcli/node-gyp@4.0.0': {}
+
+  '@npmcli/node-gyp@5.0.0': {}
 
   '@npmcli/package-json@6.2.0':
     dependencies:
@@ -12167,33 +11587,38 @@ snapshots:
       hosted-git-info: 8.1.0
       json-parse-even-better-errors: 4.0.0
       proc-log: 5.0.0
-      semver: 7.7.3
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
 
-  '@npmcli/package-json@7.0.1':
+  '@npmcli/package-json@7.0.5':
     dependencies:
-      '@npmcli/git': 7.0.0
-      glob: 11.1.0
+      '@npmcli/git': 7.0.2
+      glob: 13.0.6
       hosted-git-info: 9.0.2
-      json-parse-even-better-errors: 4.0.0
-      proc-log: 5.0.0
-      semver: 7.7.3
-      validate-npm-package-license: 3.0.4
+      json-parse-even-better-errors: 5.0.0
+      proc-log: 6.1.0
+      semver: 7.7.4
+      spdx-expression-parse: 4.0.0
 
   '@npmcli/promise-spawn@8.0.3':
     dependencies:
       which: 5.0.0
 
+  '@npmcli/promise-spawn@9.0.1':
+    dependencies:
+      which: 6.0.1
+
   '@npmcli/redact@3.2.2': {}
 
-  '@npmcli/run-script@10.0.0':
+  '@npmcli/redact@4.0.0': {}
+
+  '@npmcli/run-script@10.0.4':
     dependencies:
-      '@npmcli/node-gyp': 4.0.0
-      '@npmcli/package-json': 7.0.1
-      '@npmcli/promise-spawn': 8.0.3
-      node-gyp: 11.4.2
-      proc-log: 5.0.0
-      which: 5.0.0
+      '@npmcli/node-gyp': 5.0.0
+      '@npmcli/package-json': 7.0.5
+      '@npmcli/promise-spawn': 9.0.1
+      node-gyp: 12.2.0
+      proc-log: 6.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12202,7 +11627,7 @@ snapshots:
       '@npmcli/node-gyp': 4.0.0
       '@npmcli/package-json': 6.2.0
       '@npmcli/promise-spawn': 8.0.3
-      node-gyp: 11.4.2
+      node-gyp: 11.5.0
       proc-log: 5.0.0
       which: 5.0.0
     transitivePeerDependencies:
@@ -12210,125 +11635,126 @@ snapshots:
 
   '@octokit/auth-token@6.0.0': {}
 
-  '@octokit/core@7.0.5':
+  '@octokit/core@7.0.6':
     dependencies:
       '@octokit/auth-token': 6.0.0
-      '@octokit/graphql': 9.0.2
-      '@octokit/request': 10.0.5
-      '@octokit/request-error': 7.0.1
-      '@octokit/types': 15.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
       before-after-hook: 4.0.0
       universal-user-agent: 7.0.3
 
-  '@octokit/endpoint@11.0.1':
+  '@octokit/endpoint@11.0.3':
     dependencies:
-      '@octokit/types': 15.0.0
+      '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
-  '@octokit/graphql@9.0.2':
+  '@octokit/graphql@9.0.3':
     dependencies:
-      '@octokit/request': 10.0.5
-      '@octokit/types': 15.0.0
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
-  '@octokit/openapi-types@26.0.0': {}
+  '@octokit/openapi-types@27.0.0': {}
 
-  '@octokit/plugin-paginate-rest@13.2.0(@octokit/core@7.0.5)':
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
     dependencies:
-      '@octokit/core': 7.0.5
-      '@octokit/types': 15.0.0
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
 
-  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.5)':
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.6)':
     dependencies:
-      '@octokit/core': 7.0.5
+      '@octokit/core': 7.0.6
 
-  '@octokit/plugin-rest-endpoint-methods@16.1.0(@octokit/core@7.0.5)':
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
     dependencies:
-      '@octokit/core': 7.0.5
-      '@octokit/types': 15.0.0
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
 
-  '@octokit/request-error@7.0.1':
+  '@octokit/request-error@7.1.0':
     dependencies:
-      '@octokit/types': 15.0.0
+      '@octokit/types': 16.0.0
 
-  '@octokit/request@10.0.5':
+  '@octokit/request@10.0.8':
     dependencies:
-      '@octokit/endpoint': 11.0.1
-      '@octokit/request-error': 7.0.1
-      '@octokit/types': 15.0.0
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
       fast-content-type-parse: 3.0.0
+      json-with-bigint: 3.5.7
       universal-user-agent: 7.0.3
 
-  '@octokit/rest@22.0.0':
+  '@octokit/rest@22.0.1':
     dependencies:
-      '@octokit/core': 7.0.5
-      '@octokit/plugin-paginate-rest': 13.2.0(@octokit/core@7.0.5)
-      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.5)
-      '@octokit/plugin-rest-endpoint-methods': 16.1.0(@octokit/core@7.0.5)
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
 
-  '@octokit/types@15.0.0':
+  '@octokit/types@16.0.0':
     dependencies:
-      '@octokit/openapi-types': 26.0.0
+      '@octokit/openapi-types': 27.0.0
 
-  '@parcel/watcher-android-arm64@2.5.1':
+  '@parcel/watcher-android-arm64@2.5.6':
     optional: true
 
-  '@parcel/watcher-darwin-arm64@2.5.1':
+  '@parcel/watcher-darwin-arm64@2.5.6':
     optional: true
 
-  '@parcel/watcher-darwin-x64@2.5.1':
+  '@parcel/watcher-darwin-x64@2.5.6':
     optional: true
 
-  '@parcel/watcher-freebsd-x64@2.5.1':
+  '@parcel/watcher-freebsd-x64@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-arm-glibc@2.5.1':
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-arm-musl@2.5.1':
+  '@parcel/watcher-linux-arm-musl@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-arm64-glibc@2.5.1':
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-arm64-musl@2.5.1':
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-x64-glibc@2.5.1':
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-x64-musl@2.5.1':
+  '@parcel/watcher-linux-x64-musl@2.5.6':
     optional: true
 
-  '@parcel/watcher-win32-arm64@2.5.1':
+  '@parcel/watcher-win32-arm64@2.5.6':
     optional: true
 
-  '@parcel/watcher-win32-ia32@2.5.1':
+  '@parcel/watcher-win32-ia32@2.5.6':
     optional: true
 
-  '@parcel/watcher-win32-x64@2.5.1':
+  '@parcel/watcher-win32-x64@2.5.6':
     optional: true
 
-  '@parcel/watcher@2.5.1':
+  '@parcel/watcher@2.5.6':
     dependencies:
-      detect-libc: 1.0.3
+      detect-libc: 2.1.2
       is-glob: 4.0.3
-      micromatch: 4.0.8
       node-addon-api: 7.1.1
+      picomatch: 4.0.3
     optionalDependencies:
-      '@parcel/watcher-android-arm64': 2.5.1
-      '@parcel/watcher-darwin-arm64': 2.5.1
-      '@parcel/watcher-darwin-x64': 2.5.1
-      '@parcel/watcher-freebsd-x64': 2.5.1
-      '@parcel/watcher-linux-arm-glibc': 2.5.1
-      '@parcel/watcher-linux-arm-musl': 2.5.1
-      '@parcel/watcher-linux-arm64-glibc': 2.5.1
-      '@parcel/watcher-linux-arm64-musl': 2.5.1
-      '@parcel/watcher-linux-x64-glibc': 2.5.1
-      '@parcel/watcher-linux-x64-musl': 2.5.1
-      '@parcel/watcher-win32-arm64': 2.5.1
-      '@parcel/watcher-win32-ia32': 2.5.1
-      '@parcel/watcher-win32-x64': 2.5.1
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
     optional: true
 
   '@pkgjs/parseargs@0.11.0':
@@ -12448,16 +11874,16 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
-  '@rollup/wasm-node@4.53.2':
+  '@rollup/wasm-node@4.59.0':
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
 
-  '@schematics/angular@19.2.20(chokidar@4.0.3)':
+  '@schematics/angular@19.2.22(chokidar@4.0.3)':
     dependencies:
-      '@angular-devkit/core': 19.2.20(chokidar@4.0.3)
-      '@angular-devkit/schematics': 19.2.20(chokidar@4.0.3)
+      '@angular-devkit/core': 19.2.22(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.22(chokidar@4.0.3)
       jsonc-parser: 3.3.1
     transitivePeerDependencies:
       - chokidar
@@ -12472,7 +11898,7 @@ snapshots:
 
   '@sigstore/core@2.0.0': {}
 
-  '@sigstore/core@3.0.0': {}
+  '@sigstore/core@3.1.0': {}
 
   '@sigstore/protobuf-specs@0.4.3': {}
 
@@ -12489,13 +11915,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/sign@4.0.1':
+  '@sigstore/sign@4.1.0':
     dependencies:
       '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.0.0
+      '@sigstore/core': 3.1.0
       '@sigstore/protobuf-specs': 0.5.0
-      make-fetch-happen: 15.0.2
-      proc-log: 5.0.0
+      make-fetch-happen: 15.0.4
+      proc-log: 6.1.0
       promise-retry: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -12507,10 +11933,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/tuf@4.0.0':
+  '@sigstore/tuf@4.0.1':
     dependencies:
       '@sigstore/protobuf-specs': 0.5.0
-      tuf-js: 4.0.0
+      tuf-js: 4.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12520,113 +11946,100 @@ snapshots:
       '@sigstore/core': 2.0.0
       '@sigstore/protobuf-specs': 0.4.3
 
-  '@sigstore/verify@3.0.0':
+  '@sigstore/verify@3.1.0':
     dependencies:
       '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.0.0
+      '@sigstore/core': 3.1.0
       '@sigstore/protobuf-specs': 0.5.0
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@smithy/abort-controller@4.2.11':
+  '@smithy/abort-controller@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/config-resolver@4.4.10':
+  '@smithy/config-resolver@4.4.11':
     dependencies:
-      '@smithy/node-config-provider': 4.3.11
-      '@smithy/types': 4.13.0
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.3.2
-      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
-  '@smithy/config-resolver@4.4.6':
+  '@smithy/core@3.23.11':
     dependencies:
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
-      '@smithy/util-config-provider': 4.2.0
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      tslib: 2.8.1
-
-  '@smithy/core@3.23.9':
-    dependencies:
-      '@smithy/middleware-serde': 4.2.12
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.11
-      '@smithy/util-stream': 4.5.17
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.19
       '@smithy/util-utf8': 4.2.2
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.2.11':
+  '@smithy/credential-provider-imds@4.2.12':
     dependencies:
-      '@smithy/node-config-provider': 4.3.11
-      '@smithy/property-provider': 4.2.11
-      '@smithy/types': 4.13.0
-      '@smithy/url-parser': 4.2.11
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
       tslib: 2.8.1
 
-  '@smithy/eventstream-codec@4.2.11':
+  '@smithy/eventstream-codec@4.2.12':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-hex-encoding': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-browser@4.2.11':
+  '@smithy/eventstream-serde-browser@4.2.12':
     dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.11
-      '@smithy/types': 4.13.0
+      '@smithy/eventstream-serde-universal': 4.2.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-config-resolver@4.3.11':
+  '@smithy/eventstream-serde-config-resolver@4.3.12':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-node@4.2.11':
+  '@smithy/eventstream-serde-node@4.2.12':
     dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.11
-      '@smithy/types': 4.13.0
+      '@smithy/eventstream-serde-universal': 4.2.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-universal@4.2.11':
+  '@smithy/eventstream-serde-universal@4.2.12':
     dependencies:
-      '@smithy/eventstream-codec': 4.2.11
-      '@smithy/types': 4.13.0
+      '@smithy/eventstream-codec': 4.2.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/fetch-http-handler@5.3.13':
+  '@smithy/fetch-http-handler@5.3.15':
     dependencies:
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/querystring-builder': 4.2.11
-      '@smithy/types': 4.13.0
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/querystring-builder': 4.2.12
+      '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
-  '@smithy/hash-node@4.2.11':
+  '@smithy/hash-node@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/invalid-dependency@4.2.11':
+  '@smithy/invalid-dependency@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/is-array-buffer@4.2.0':
     dependencies:
       tslib: 2.8.1
 
@@ -12634,147 +12047,121 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/middleware-content-length@4.2.11':
+  '@smithy/middleware-content-length@4.2.12':
     dependencies:
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.4.23':
+  '@smithy/middleware-endpoint@4.4.25':
     dependencies:
-      '@smithy/core': 3.23.9
-      '@smithy/middleware-serde': 4.2.12
-      '@smithy/node-config-provider': 4.3.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
-      '@smithy/url-parser': 4.2.11
-      '@smithy/util-middleware': 4.2.11
+      '@smithy/core': 3.23.11
+      '@smithy/middleware-serde': 4.2.14
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
-  '@smithy/middleware-retry@4.4.40':
+  '@smithy/middleware-retry@4.4.42':
     dependencies:
-      '@smithy/node-config-provider': 4.3.11
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/service-error-classification': 4.2.11
-      '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.13.0
-      '@smithy/util-middleware': 4.2.11
-      '@smithy/util-retry': 4.2.11
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/service-error-classification': 4.2.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/middleware-serde@4.2.12':
+  '@smithy/middleware-serde@4.2.14':
     dependencies:
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
+      '@smithy/core': 3.23.11
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/middleware-stack@4.2.11':
+  '@smithy/middleware-stack@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/node-config-provider@4.3.11':
+  '@smithy/node-config-provider@4.3.12':
     dependencies:
-      '@smithy/property-provider': 4.2.11
-      '@smithy/shared-ini-file-loader': 4.4.6
-      '@smithy/types': 4.13.0
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/node-config-provider@4.3.8':
+  '@smithy/node-http-handler@4.4.16':
     dependencies:
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/abort-controller': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/querystring-builder': 4.2.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.4.14':
+  '@smithy/property-provider@4.2.12':
     dependencies:
-      '@smithy/abort-controller': 4.2.11
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/querystring-builder': 4.2.11
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/property-provider@4.2.11':
+  '@smithy/protocol-http@5.3.12':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/property-provider@4.2.8':
+  '@smithy/querystring-builder@4.2.12':
     dependencies:
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@5.3.11':
-    dependencies:
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/querystring-builder@4.2.11':
-    dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/querystring-parser@4.2.11':
+  '@smithy/querystring-parser@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/service-error-classification@4.2.11':
+  '@smithy/service-error-classification@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
 
-  '@smithy/shared-ini-file-loader@4.4.3':
+  '@smithy/shared-ini-file-loader@4.4.7':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/shared-ini-file-loader@4.4.6':
-    dependencies:
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.3.11':
+  '@smithy/signature-v4@5.3.12':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
       '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-middleware': 4.2.12
       '@smithy/util-uri-escape': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/smithy-client@4.12.3':
+  '@smithy/smithy-client@4.12.5':
     dependencies:
-      '@smithy/core': 3.23.9
-      '@smithy/middleware-endpoint': 4.4.23
-      '@smithy/middleware-stack': 4.2.11
-      '@smithy/protocol-http': 5.3.11
-      '@smithy/types': 4.13.0
-      '@smithy/util-stream': 4.5.17
+      '@smithy/core': 3.23.11
+      '@smithy/middleware-endpoint': 4.4.25
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-stream': 4.5.19
       tslib: 2.8.1
 
-  '@smithy/types@4.12.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/types@4.13.0':
+  '@smithy/types@4.13.1':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/url-parser@4.2.11':
+  '@smithy/url-parser@4.2.12':
     dependencies:
-      '@smithy/querystring-parser': 4.2.11
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/util-base64@4.3.0':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.0
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/querystring-parser': 4.2.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/util-base64@4.3.2':
@@ -12783,15 +12170,7 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/util-body-length-browser@4.2.0':
-    dependencies:
-      tslib: 2.8.1
-
   '@smithy/util-body-length-browser@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-node@4.2.1':
     dependencies:
       tslib: 2.8.1
 
@@ -12804,78 +12183,58 @@ snapshots:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.8.1
 
-  '@smithy/util-buffer-from@4.2.0':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.0
-      tslib: 2.8.1
-
   '@smithy/util-buffer-from@4.2.2':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-config-provider@4.2.0':
-    dependencies:
       tslib: 2.8.1
 
   '@smithy/util-config-provider@4.2.2':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-browser@4.3.39':
+  '@smithy/util-defaults-mode-browser@4.3.41':
     dependencies:
-      '@smithy/property-provider': 4.2.11
-      '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.13.0
+      '@smithy/property-provider': 4.2.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-node@4.2.42':
+  '@smithy/util-defaults-mode-node@4.2.44':
     dependencies:
-      '@smithy/config-resolver': 4.4.10
-      '@smithy/credential-provider-imds': 4.2.11
-      '@smithy/node-config-provider': 4.3.11
-      '@smithy/property-provider': 4.2.11
-      '@smithy/smithy-client': 4.12.3
-      '@smithy/types': 4.13.0
+      '@smithy/config-resolver': 4.4.11
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/smithy-client': 4.12.5
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-endpoints@3.2.8':
+  '@smithy/util-endpoints@3.3.3':
     dependencies:
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@smithy/util-endpoints@3.3.2':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.11
-      '@smithy/types': 4.13.0
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/util-hex-encoding@4.2.2':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/util-middleware@4.2.11':
+  '@smithy/util-middleware@4.2.12':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-middleware@4.2.8':
+  '@smithy/util-retry@4.2.12':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/service-error-classification': 4.2.12
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-retry@4.2.11':
+  '@smithy/util-stream@4.5.19':
     dependencies:
-      '@smithy/service-error-classification': 4.2.11
-      '@smithy/types': 4.13.0
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.5.17':
-    dependencies:
-      '@smithy/fetch-http-handler': 5.3.13
-      '@smithy/node-http-handler': 4.4.14
-      '@smithy/types': 4.13.0
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/node-http-handler': 4.4.16
+      '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.2
@@ -12891,11 +12250,6 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
-  '@smithy/util-utf8@4.2.0':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.0
-      tslib: 2.8.1
-
   '@smithy/util-utf8@4.2.2':
     dependencies:
       '@smithy/util-buffer-from': 4.2.2
@@ -12907,12 +12261,12 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@standard-schema/spec@1.0.0': {}
+  '@standard-schema/spec@1.1.0': {}
 
-  '@stylistic/eslint-plugin@4.4.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)':
+  '@stylistic/eslint-plugin@4.4.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)':
     dependencies:
-      '@typescript-eslint/utils': 8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
-      eslint: 9.38.0(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
@@ -12926,7 +12280,7 @@ snapshots:
   '@ts-morph/common@0.22.0':
     dependencies:
       fast-glob: 3.3.3
-      minimatch: 9.0.6
+      minimatch: 9.0.9
       mkdirp: 3.0.1
       path-browserify: 1.0.1
 
@@ -12935,12 +12289,12 @@ snapshots:
   '@tufjs/models@3.0.1':
     dependencies:
       '@tufjs/canonical-json': 2.0.0
-      minimatch: 9.0.6
+      minimatch: 9.0.9
 
-  '@tufjs/models@4.0.0':
+  '@tufjs/models@4.1.0':
     dependencies:
       '@tufjs/canonical-json': 2.0.0
-      minimatch: 9.0.6
+      minimatch: 10.2.4
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -12964,17 +12318,12 @@ snapshots:
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
-      '@types/express-serve-static-core': 5.1.0
+      '@types/express-serve-static-core': 4.19.8
       '@types/node': 14.18.63
 
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 14.18.63
-
-  '@types/cors@2.8.19':
-    dependencies:
-      '@types/node': 14.18.63
-    optional: true
 
   '@types/debug@4.1.12':
     dependencies:
@@ -12994,26 +12343,19 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/express-serve-static-core@4.19.7':
+  '@types/express-serve-static-core@4.19.8':
     dependencies:
       '@types/node': 14.18.63
-      '@types/qs': 6.14.0
+      '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
-      '@types/send': 1.2.0
+      '@types/send': 1.2.1
 
-  '@types/express-serve-static-core@5.1.0':
-    dependencies:
-      '@types/node': 14.18.63
-      '@types/qs': 6.14.0
-      '@types/range-parser': 1.2.7
-      '@types/send': 1.2.0
-
-  '@types/express@4.17.23':
+  '@types/express@4.17.25':
     dependencies:
       '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 4.19.7
-      '@types/qs': 6.14.0
-      '@types/serve-static': 1.15.9
+      '@types/express-serve-static-core': 4.19.8
+      '@types/qs': 6.15.0
+      '@types/serve-static': 1.15.10
 
   '@types/hast@3.0.4':
     dependencies:
@@ -13021,7 +12363,7 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
-  '@types/http-proxy@1.17.16':
+  '@types/http-proxy@1.17.17':
     dependencies:
       '@types/node': 14.18.63
 
@@ -13047,32 +12389,32 @@ snapshots:
 
   '@types/postcss-import@14.0.3':
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
-  '@types/qs@6.14.0': {}
+  '@types/qs@6.15.0': {}
 
   '@types/range-parser@1.2.7': {}
 
   '@types/retry@0.12.2': {}
 
-  '@types/send@0.17.5':
+  '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
       '@types/node': 14.18.63
 
-  '@types/send@1.2.0':
+  '@types/send@1.2.1':
     dependencies:
       '@types/node': 14.18.63
 
   '@types/serve-index@1.9.4':
     dependencies:
-      '@types/express': 4.17.23
+      '@types/express': 4.17.25
 
-  '@types/serve-static@1.15.9':
+  '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 14.18.63
-      '@types/send': 0.17.5
+      '@types/send': 0.17.6
 
   '@types/sinonjs__fake-timers@8.1.1': {}
 
@@ -13097,98 +12439,96 @@ snapshots:
       '@types/node': 14.18.63
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.46.1(@typescript-eslint/parser@8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4))(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4))(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)':
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.46.1
-      '@typescript-eslint/type-utils': 8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
-      '@typescript-eslint/visitor-keys': 8.46.1
-      eslint: 9.38.0(jiti@2.6.1)
-      graphemer: 1.4.0
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/type-utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
+      '@typescript-eslint/visitor-keys': 8.57.0
+      eslint: 9.39.4(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.5.4)
+      ts-api-utils: 2.4.0(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)':
+  '@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.46.1
-      '@typescript-eslint/types': 8.46.1
-      '@typescript-eslint/typescript-estree': 8.46.1(typescript@5.5.4)
-      '@typescript-eslint/visitor-keys': 8.46.1
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.5.4)
+      '@typescript-eslint/visitor-keys': 8.57.0
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.38.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.46.1(typescript@5.5.4)':
+  '@typescript-eslint/project-service@8.57.0(typescript@5.5.4)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.46.1(typescript@5.5.4)
-      '@typescript-eslint/types': 8.46.1
+      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.5.4)
+      '@typescript-eslint/types': 8.57.0
       debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.46.1':
+  '@typescript-eslint/scope-manager@8.57.0':
     dependencies:
-      '@typescript-eslint/types': 8.46.1
-      '@typescript-eslint/visitor-keys': 8.46.1
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/visitor-keys': 8.57.0
 
-  '@typescript-eslint/tsconfig-utils@8.46.1(typescript@5.5.4)':
+  '@typescript-eslint/tsconfig-utils@8.57.0(typescript@5.5.4)':
     dependencies:
       typescript: 5.5.4
 
-  '@typescript-eslint/type-utils@8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)':
     dependencies:
-      '@typescript-eslint/types': 8.46.1
-      '@typescript-eslint/typescript-estree': 8.46.1(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.38.0(jiti@2.6.1)
-      ts-api-utils: 2.1.0(typescript@5.5.4)
+      eslint: 9.39.4(jiti@2.6.1)
+      ts-api-utils: 2.4.0(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.46.1': {}
+  '@typescript-eslint/types@8.57.0': {}
 
-  '@typescript-eslint/typescript-estree@8.46.1(typescript@5.5.4)':
+  '@typescript-eslint/typescript-estree@8.57.0(typescript@5.5.4)':
     dependencies:
-      '@typescript-eslint/project-service': 8.46.1(typescript@5.5.4)
-      '@typescript-eslint/tsconfig-utils': 8.46.1(typescript@5.5.4)
-      '@typescript-eslint/types': 8.46.1
-      '@typescript-eslint/visitor-keys': 8.46.1
+      '@typescript-eslint/project-service': 8.57.0(typescript@5.5.4)
+      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.5.4)
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/visitor-keys': 8.57.0
       debug: 4.4.3(supports-color@8.1.1)
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 9.0.6
-      semver: 7.7.3
-      ts-api-utils: 2.1.0(typescript@5.5.4)
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)':
+  '@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.46.1
-      '@typescript-eslint/types': 8.46.1
-      '@typescript-eslint/typescript-estree': 8.46.1(typescript@5.5.4)
-      eslint: 9.38.0(jiti@2.6.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.5.4)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.46.1':
+  '@typescript-eslint/visitor-keys@8.57.0':
     dependencies:
-      '@typescript-eslint/types': 8.46.1
-      eslint-visitor-keys: 4.2.1
+      '@typescript-eslint/types': 8.57.0
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -13213,7 +12553,7 @@ snapshots:
   '@uploadcare/upload-client@6.14.3':
     dependencies:
       form-data: 4.0.5
-      ws: 8.18.3
+      ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -13221,99 +12561,101 @@ snapshots:
   '@uploadcare/upload-client@6.18.4':
     dependencies:
       form-data: 4.0.5
-      ws: 8.18.3
+      ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@vitejs/plugin-basic-ssl@1.2.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))':
+  '@vitejs/plugin-basic-ssl@1.2.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))':
     dependencies:
-      vite: 6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2)
 
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.1.0(playwright@1.58.2)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(vitest@4.1.0)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))
+      '@vitest/browser': 4.1.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(vitest@4.1.0)
+      '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
       playwright: 1.58.2
-      tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@14.18.63)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1)
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@types/node@14.18.63)(@vitest/browser-playwright@4.1.0)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(vitest@4.0.18)':
+  '@vitest/browser@4.1.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(vitest@4.1.0)':
     dependencies:
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))
-      '@vitest/utils': 4.0.18
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
+      '@vitest/utils': 4.1.0
       magic-string: 0.30.21
-      pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
-      tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@14.18.63)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1)
-      ws: 8.18.3
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@types/node@14.18.63)(@vitest/browser-playwright@4.1.0)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
+      ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.1.0(@vitest/browser@4.1.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(vitest@4.1.0))(vitest@4.1.0)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.0.18
-      ast-v8-to-istanbul: 0.3.11
+      '@vitest/utils': 4.1.0
+      ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.1
+      magicast: 0.5.2
       obug: 2.1.1
-      std-env: 3.10.0
-      tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@14.18.63)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1)
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@types/node@14.18.63)(@vitest/browser-playwright@4.1.0)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser': 4.1.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(vitest@4.1.0)
 
-  '@vitest/expect@4.0.18':
+  '@vitest/expect@4.1.0':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      chai: 6.2.1
-      tinyrainbow: 3.0.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.1.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))':
     dependencies:
-      '@vitest/spy': 4.0.18
+      '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1)
+      vite: 6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2)
 
-  '@vitest/pretty-format@4.0.18':
+  '@vitest/pretty-format@4.1.0':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.0.18':
+  '@vitest/runner@4.1.0':
     dependencies:
-      '@vitest/utils': 4.0.18
+      '@vitest/utils': 4.1.0
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.18':
+  '@vitest/snapshot@4.1.0':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.18': {}
+  '@vitest/spy@4.1.0': {}
 
-  '@vitest/utils@4.0.18':
+  '@vitest/utils@4.1.0':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
-      tinyrainbow: 3.0.3
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -13391,22 +12733,22 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.105.2)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.105.2)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.2)(webpack@5.105.2)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.2)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
     optionalDependencies:
-      webpack-dev-server: 5.2.2(webpack-cli@5.1.4)(webpack@5.105.2)
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4)
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -13416,20 +12758,22 @@ snapshots:
 
   abbrev@3.0.1: {}
 
+  abbrev@4.0.0: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-import-phases@1.0.4(acorn@8.15.0):
+  acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
+  acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
-  acorn@8.15.0: {}
+  acorn@8.16.0: {}
 
   adjust-sourcemap-loader@4.0.0:
     dependencies:
@@ -13480,7 +12824,7 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
-  ansi-escapes@7.2.0:
+  ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
 
@@ -13523,7 +12867,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@0.3.11:
+  ast-v8-to-istanbul@1.0.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -13540,7 +12884,7 @@ snapshots:
   autoprefixer@10.4.20(postcss@8.5.2):
     dependencies:
       browserslist: 4.28.1
-      caniuse-lite: 1.0.30001750
+      caniuse-lite: 1.0.30001778
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -13551,7 +12895,7 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5(debug@4.4.3):
+  axios@1.13.6(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
@@ -13559,24 +12903,25 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  babel-loader@10.0.0(@babel/core@7.28.4)(webpack@5.105.2):
+  babel-loader@10.1.1(@babel/core@7.26.10)(webpack@5.105.4):
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.26.10
       find-up: 5.0.0
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+    optionalDependencies:
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
-  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.105.2):
+  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.105.4):
     dependencies:
       '@babel/core': 7.26.10
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
-  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.26.10):
+  babel-plugin-polyfill-corejs2@0.4.16(@babel/core@7.26.10):
     dependencies:
-      '@babel/compat-data': 7.28.4
+      '@babel/compat-data': 7.29.0
       '@babel/core': 7.26.10
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.26.10)
+      '@babel/helper-define-polyfill-provider': 0.6.7(@babel/core@7.26.10)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -13584,15 +12929,15 @@ snapshots:
   babel-plugin-polyfill-corejs3@0.11.1(@babel/core@7.26.10):
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.26.10)
-      core-js-compat: 3.46.0
+      '@babel/helper-define-polyfill-provider': 0.6.7(@babel/core@7.26.10)
+      core-js-compat: 3.48.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.26.10):
+  babel-plugin-polyfill-regenerator@0.6.7(@babel/core@7.26.10):
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.26.10)
+      '@babel/helper-define-polyfill-provider': 0.6.7(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
 
@@ -13604,10 +12949,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  base64id@2.0.0:
-    optional: true
-
-  baseline-browser-mapping@2.9.19: {}
+  baseline-browser-mapping@2.10.7: {}
 
   batch@0.6.1: {}
 
@@ -13621,9 +12963,9 @@ snapshots:
       css-what: 6.2.2
       dom-serializer: 2.0.0
       domhandler: 5.0.3
-      htmlparser2: 10.0.0
+      htmlparser2: 10.1.0
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.2
       postcss-media-query-parser: 0.2.3
 
   before-after-hook@4.0.0: {}
@@ -13644,23 +12986,6 @@ snapshots:
 
   blurhash@2.0.5: {}
 
-  body-parser@1.20.3:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      http-errors: 2.0.0
-      iconv-lite: 0.4.24
-      on-finished: 2.4.1
-      qs: 6.15.0
-      raw-body: 2.5.2
-      type-is: 1.6.18
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   body-parser@1.20.4:
     dependencies:
       bytes: 3.1.2
@@ -13677,7 +13002,6 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   bonjour-service@1.3.0:
     dependencies:
@@ -13686,14 +13010,18 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  bowser@2.12.1: {}
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.3:
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
 
@@ -13703,20 +13031,12 @@ snapshots:
 
   browser-stdout@1.3.1: {}
 
-  browserslist@4.26.3:
-    dependencies:
-      baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001750
-      electron-to-chromium: 1.5.235
-      node-releases: 2.0.23
-      update-browserslist-db: 1.1.3(browserslist@4.26.3)
-
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001774
-      electron-to-chromium: 1.5.302
-      node-releases: 2.0.27
+      baseline-browser-mapping: 2.10.7
+      caniuse-lite: 1.0.30001778
+      electron-to-chromium: 1.5.313
+      node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-crc32@0.2.13: {}
@@ -13740,28 +13060,28 @@ snapshots:
       fs-minipass: 3.0.3
       glob: 10.5.0
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-collect: 2.0.1
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
-      p-map: 7.0.3
+      p-map: 7.0.4
       ssri: 12.0.0
-      tar: 7.5.9
+      tar: 7.5.11
       unique-filename: 4.0.0
 
-  cacache@20.0.1:
+  cacache@20.0.3:
     dependencies:
-      '@npmcli/fs': 4.0.0
+      '@npmcli/fs': 5.0.0
       fs-minipass: 3.0.3
-      glob: 11.1.0
-      lru-cache: 11.2.2
-      minipass: 7.1.2
+      glob: 13.0.6
+      lru-cache: 11.2.7
+      minipass: 7.1.3
       minipass-collect: 2.0.1
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
-      p-map: 7.0.3
-      ssri: 12.0.0
-      unique-filename: 4.0.0
+      p-map: 7.0.4
+      ssri: 13.0.1
+      unique-filename: 5.0.0
 
   cachedir@2.4.0: {}
 
@@ -13784,19 +13104,17 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.28.1
-      caniuse-lite: 1.0.30001774
+      caniuse-lite: 1.0.30001778
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001750: {}
-
-  caniuse-lite@1.0.30001774: {}
+  caniuse-lite@1.0.30001778: {}
 
   caseless@0.12.0: {}
 
   ccount@2.0.1: {}
 
-  chai@6.2.1: {}
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -13809,7 +13127,7 @@ snapshots:
 
   character-entities@2.0.2: {}
 
-  chardet@2.1.0: {}
+  chardet@2.1.1: {}
 
   check-more-types@2.24.0: {}
 
@@ -13833,177 +13151,111 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
-  ci-info@4.3.1: {}
+  ci-info@4.4.0: {}
 
-  ckeditor5-collaboration@47.6.0:
+  ckeditor5-collaboration@47.6.1:
     dependencies:
-      '@ckeditor/ckeditor5-collaboration-core': 47.6.0
+      '@ckeditor/ckeditor5-collaboration-core': 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  ckeditor5-premium-features@47.6.0(ckeditor5@47.6.0):
+  ckeditor5-premium-features@47.6.1(ckeditor5@47.6.1):
     dependencies:
-      '@ckeditor/ckeditor5-ai': 47.6.0
-      '@ckeditor/ckeditor5-case-change': 47.6.0
-      '@ckeditor/ckeditor5-collaboration-core': 47.6.0
-      '@ckeditor/ckeditor5-comments': 47.6.0
-      '@ckeditor/ckeditor5-document-outline': 47.6.0
-      '@ckeditor/ckeditor5-email': 47.6.0
-      '@ckeditor/ckeditor5-export-inline-styles': 47.6.0
-      '@ckeditor/ckeditor5-export-pdf': 47.6.0
-      '@ckeditor/ckeditor5-export-word': 47.6.0
-      '@ckeditor/ckeditor5-footnotes': 47.6.0
-      '@ckeditor/ckeditor5-format-painter': 47.6.0
-      '@ckeditor/ckeditor5-import-word': 47.6.0
-      '@ckeditor/ckeditor5-line-height': 47.6.0
-      '@ckeditor/ckeditor5-list-multi-level': 47.6.0
-      '@ckeditor/ckeditor5-merge-fields': 47.6.0
-      '@ckeditor/ckeditor5-pagination': 47.6.0
-      '@ckeditor/ckeditor5-paste-from-office-enhanced': 47.6.0
-      '@ckeditor/ckeditor5-real-time-collaboration': 47.6.0
-      '@ckeditor/ckeditor5-revision-history': 47.6.0
-      '@ckeditor/ckeditor5-slash-command': 47.6.0
-      '@ckeditor/ckeditor5-source-editing-enhanced': 47.6.0
-      '@ckeditor/ckeditor5-template': 47.6.0
-      '@ckeditor/ckeditor5-track-changes': 47.6.0
-      '@ckeditor/ckeditor5-uploadcare': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ai': 47.6.1
+      '@ckeditor/ckeditor5-case-change': 47.6.1
+      '@ckeditor/ckeditor5-collaboration-core': 47.6.1
+      '@ckeditor/ckeditor5-comments': 47.6.1
+      '@ckeditor/ckeditor5-document-outline': 47.6.1
+      '@ckeditor/ckeditor5-email': 47.6.1
+      '@ckeditor/ckeditor5-export-inline-styles': 47.6.1
+      '@ckeditor/ckeditor5-export-pdf': 47.6.1
+      '@ckeditor/ckeditor5-export-word': 47.6.1
+      '@ckeditor/ckeditor5-footnotes': 47.6.1
+      '@ckeditor/ckeditor5-format-painter': 47.6.1
+      '@ckeditor/ckeditor5-import-word': 47.6.1
+      '@ckeditor/ckeditor5-line-height': 47.6.1
+      '@ckeditor/ckeditor5-list-multi-level': 47.6.1
+      '@ckeditor/ckeditor5-merge-fields': 47.6.1
+      '@ckeditor/ckeditor5-pagination': 47.6.1
+      '@ckeditor/ckeditor5-paste-from-office-enhanced': 47.6.1
+      '@ckeditor/ckeditor5-real-time-collaboration': 47.6.1
+      '@ckeditor/ckeditor5-revision-history': 47.6.1
+      '@ckeditor/ckeditor5-slash-command': 47.6.1
+      '@ckeditor/ckeditor5-source-editing-enhanced': 47.6.1
+      '@ckeditor/ckeditor5-template': 47.6.1
+      '@ckeditor/ckeditor5-track-changes': 47.6.1
+      '@ckeditor/ckeditor5-uploadcare': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - aws-crt
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  ckeditor5@47.2.0:
+  ckeditor5@47.6.1:
     dependencies:
-      '@ckeditor/ckeditor5-adapter-ckfinder': 47.2.0
-      '@ckeditor/ckeditor5-alignment': 47.2.0
-      '@ckeditor/ckeditor5-autoformat': 47.2.0
-      '@ckeditor/ckeditor5-autosave': 47.2.0
-      '@ckeditor/ckeditor5-basic-styles': 47.2.0
-      '@ckeditor/ckeditor5-block-quote': 47.2.0
-      '@ckeditor/ckeditor5-bookmark': 47.2.0
-      '@ckeditor/ckeditor5-ckbox': 47.2.0
-      '@ckeditor/ckeditor5-ckfinder': 47.2.0
-      '@ckeditor/ckeditor5-clipboard': 47.2.0
-      '@ckeditor/ckeditor5-cloud-services': 47.2.0
-      '@ckeditor/ckeditor5-code-block': 47.2.0
-      '@ckeditor/ckeditor5-core': 47.2.0
-      '@ckeditor/ckeditor5-easy-image': 47.2.0
-      '@ckeditor/ckeditor5-editor-balloon': 47.2.0
-      '@ckeditor/ckeditor5-editor-classic': 47.2.0
-      '@ckeditor/ckeditor5-editor-decoupled': 47.2.0
-      '@ckeditor/ckeditor5-editor-inline': 47.2.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.2.0
-      '@ckeditor/ckeditor5-emoji': 47.2.0
-      '@ckeditor/ckeditor5-engine': 47.2.0
-      '@ckeditor/ckeditor5-enter': 47.2.0
-      '@ckeditor/ckeditor5-essentials': 47.2.0
-      '@ckeditor/ckeditor5-find-and-replace': 47.2.0
-      '@ckeditor/ckeditor5-font': 47.2.0
-      '@ckeditor/ckeditor5-fullscreen': 47.2.0
-      '@ckeditor/ckeditor5-heading': 47.2.0
-      '@ckeditor/ckeditor5-highlight': 47.2.0
-      '@ckeditor/ckeditor5-horizontal-line': 47.2.0
-      '@ckeditor/ckeditor5-html-embed': 47.2.0
-      '@ckeditor/ckeditor5-html-support': 47.2.0
-      '@ckeditor/ckeditor5-icons': 47.2.0
-      '@ckeditor/ckeditor5-image': 47.2.0
-      '@ckeditor/ckeditor5-indent': 47.2.0
-      '@ckeditor/ckeditor5-language': 47.2.0
-      '@ckeditor/ckeditor5-link': 47.2.0
-      '@ckeditor/ckeditor5-list': 47.2.0
-      '@ckeditor/ckeditor5-markdown-gfm': 47.2.0
-      '@ckeditor/ckeditor5-media-embed': 47.2.0
-      '@ckeditor/ckeditor5-mention': 47.2.0
-      '@ckeditor/ckeditor5-minimap': 47.2.0
-      '@ckeditor/ckeditor5-page-break': 47.2.0
-      '@ckeditor/ckeditor5-paragraph': 47.2.0
-      '@ckeditor/ckeditor5-paste-from-office': 47.2.0
-      '@ckeditor/ckeditor5-remove-format': 47.2.0
-      '@ckeditor/ckeditor5-restricted-editing': 47.2.0
-      '@ckeditor/ckeditor5-select-all': 47.2.0
-      '@ckeditor/ckeditor5-show-blocks': 47.2.0
-      '@ckeditor/ckeditor5-source-editing': 47.2.0
-      '@ckeditor/ckeditor5-special-characters': 47.2.0
-      '@ckeditor/ckeditor5-style': 47.2.0
-      '@ckeditor/ckeditor5-table': 47.2.0
-      '@ckeditor/ckeditor5-theme-lark': 47.2.0
-      '@ckeditor/ckeditor5-typing': 47.2.0
-      '@ckeditor/ckeditor5-ui': 47.2.0
-      '@ckeditor/ckeditor5-undo': 47.2.0
-      '@ckeditor/ckeditor5-upload': 47.2.0
-      '@ckeditor/ckeditor5-utils': 47.2.0
-      '@ckeditor/ckeditor5-watchdog': 47.2.0
-      '@ckeditor/ckeditor5-widget': 47.2.0
-      '@ckeditor/ckeditor5-word-count': 47.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  ckeditor5@47.6.0:
-    dependencies:
-      '@ckeditor/ckeditor5-adapter-ckfinder': 47.6.0
-      '@ckeditor/ckeditor5-alignment': 47.6.0
-      '@ckeditor/ckeditor5-autoformat': 47.6.0
-      '@ckeditor/ckeditor5-autosave': 47.6.0
-      '@ckeditor/ckeditor5-basic-styles': 47.6.0
-      '@ckeditor/ckeditor5-block-quote': 47.6.0
-      '@ckeditor/ckeditor5-bookmark': 47.6.0
-      '@ckeditor/ckeditor5-ckbox': 47.6.0
-      '@ckeditor/ckeditor5-ckfinder': 47.6.0
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
-      '@ckeditor/ckeditor5-code-block': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-easy-image': 47.6.0
-      '@ckeditor/ckeditor5-editor-balloon': 47.6.0
-      '@ckeditor/ckeditor5-editor-classic': 47.6.0
-      '@ckeditor/ckeditor5-editor-decoupled': 47.6.0
-      '@ckeditor/ckeditor5-editor-inline': 47.6.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0
-      '@ckeditor/ckeditor5-emoji': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-essentials': 47.6.0
-      '@ckeditor/ckeditor5-find-and-replace': 47.6.0
-      '@ckeditor/ckeditor5-font': 47.6.0
-      '@ckeditor/ckeditor5-fullscreen': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-highlight': 47.6.0
-      '@ckeditor/ckeditor5-horizontal-line': 47.6.0
-      '@ckeditor/ckeditor5-html-embed': 47.6.0
-      '@ckeditor/ckeditor5-html-support': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-indent': 47.6.0
-      '@ckeditor/ckeditor5-language': 47.6.0
-      '@ckeditor/ckeditor5-link': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-markdown-gfm': 47.6.0
-      '@ckeditor/ckeditor5-media-embed': 47.6.0
-      '@ckeditor/ckeditor5-mention': 47.6.0
-      '@ckeditor/ckeditor5-minimap': 47.6.0
-      '@ckeditor/ckeditor5-page-break': 47.6.0
-      '@ckeditor/ckeditor5-paragraph': 47.6.0
-      '@ckeditor/ckeditor5-paste-from-office': 47.6.0
-      '@ckeditor/ckeditor5-remove-format': 47.6.0
-      '@ckeditor/ckeditor5-restricted-editing': 47.6.0
-      '@ckeditor/ckeditor5-select-all': 47.6.0
-      '@ckeditor/ckeditor5-show-blocks': 47.6.0
-      '@ckeditor/ckeditor5-source-editing': 47.6.0
-      '@ckeditor/ckeditor5-special-characters': 47.6.0
-      '@ckeditor/ckeditor5-style': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-undo': 47.6.0
-      '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-watchdog': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      '@ckeditor/ckeditor5-word-count': 47.6.0
+      '@ckeditor/ckeditor5-adapter-ckfinder': 47.6.1
+      '@ckeditor/ckeditor5-alignment': 47.6.1
+      '@ckeditor/ckeditor5-autoformat': 47.6.1
+      '@ckeditor/ckeditor5-autosave': 47.6.1
+      '@ckeditor/ckeditor5-basic-styles': 47.6.1
+      '@ckeditor/ckeditor5-block-quote': 47.6.1
+      '@ckeditor/ckeditor5-bookmark': 47.6.1
+      '@ckeditor/ckeditor5-ckbox': 47.6.1
+      '@ckeditor/ckeditor5-ckfinder': 47.6.1
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-code-block': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-easy-image': 47.6.1
+      '@ckeditor/ckeditor5-editor-balloon': 47.6.1
+      '@ckeditor/ckeditor5-editor-classic': 47.6.1
+      '@ckeditor/ckeditor5-editor-decoupled': 47.6.1
+      '@ckeditor/ckeditor5-editor-inline': 47.6.1
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.1
+      '@ckeditor/ckeditor5-emoji': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-essentials': 47.6.1
+      '@ckeditor/ckeditor5-find-and-replace': 47.6.1
+      '@ckeditor/ckeditor5-font': 47.6.1
+      '@ckeditor/ckeditor5-fullscreen': 47.6.1
+      '@ckeditor/ckeditor5-heading': 47.6.1
+      '@ckeditor/ckeditor5-highlight': 47.6.1
+      '@ckeditor/ckeditor5-horizontal-line': 47.6.1
+      '@ckeditor/ckeditor5-html-embed': 47.6.1
+      '@ckeditor/ckeditor5-html-support': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-indent': 47.6.1
+      '@ckeditor/ckeditor5-language': 47.6.1
+      '@ckeditor/ckeditor5-link': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-markdown-gfm': 47.6.1
+      '@ckeditor/ckeditor5-media-embed': 47.6.1
+      '@ckeditor/ckeditor5-mention': 47.6.1
+      '@ckeditor/ckeditor5-minimap': 47.6.1
+      '@ckeditor/ckeditor5-page-break': 47.6.1
+      '@ckeditor/ckeditor5-paragraph': 47.6.1
+      '@ckeditor/ckeditor5-paste-from-office': 47.6.1
+      '@ckeditor/ckeditor5-remove-format': 47.6.1
+      '@ckeditor/ckeditor5-restricted-editing': 47.6.1
+      '@ckeditor/ckeditor5-select-all': 47.6.1
+      '@ckeditor/ckeditor5-show-blocks': 47.6.1
+      '@ckeditor/ckeditor5-source-editing': 47.6.1
+      '@ckeditor/ckeditor5-special-characters': 47.6.1
+      '@ckeditor/ckeditor5-style': 47.6.1
+      '@ckeditor/ckeditor5-table': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-undo': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-watchdog': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      '@ckeditor/ckeditor5-word-count': 47.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -14024,7 +13276,7 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
-  cli-spinners@3.3.0: {}
+  cli-spinners@3.4.0: {}
 
   cli-table3@0.6.5:
     dependencies:
@@ -14043,13 +13295,6 @@ snapshots:
       string-width: 7.2.0
 
   cli-width@4.1.0: {}
-
-  cliui@7.0.4:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-    optional: true
 
   cliui@8.0.1:
     dependencies:
@@ -14073,15 +13318,15 @@ snapshots:
 
   color-convert@3.1.0:
     dependencies:
-      color-name: 2.0.2
+      color-name: 2.1.0
 
   color-name@1.1.4: {}
 
-  color-name@2.0.2: {}
+  color-name@2.1.0: {}
 
   color-parse@2.0.2:
     dependencies:
-      color-name: 2.0.2
+      color-name: 2.1.0
 
   colord@2.9.3: {}
 
@@ -14131,16 +13376,6 @@ snapshots:
 
   connect-history-api-fallback@2.0.0: {}
 
-  connect@3.7.0:
-    dependencies:
-      debug: 2.6.9
-      finalhandler: 1.1.2
-      parseurl: 1.3.3
-      utils-merge: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
@@ -14151,18 +13386,19 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie-signature@1.0.6: {}
+  cookie-signature@1.0.7: {}
 
-  cookie@0.7.1: {}
-
-  cookie@0.7.2:
-    optional: true
+  cookie@0.7.2: {}
 
   copy-anything@2.0.6:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@12.0.2(webpack@5.105.2):
+  copy-anything@3.0.5:
+    dependencies:
+      is-what: 4.1.16
+
+  copy-webpack-plugin@12.0.2(webpack@5.105.4):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -14170,23 +13406,17 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
-  core-js-compat@3.46.0:
+  core-js-compat@3.48.0:
     dependencies:
       browserslist: 4.28.1
 
-  core-js@3.46.0: {}
+  core-js@3.48.0: {}
 
   core-util-is@1.0.2: {}
 
   core-util-is@1.0.3: {}
-
-  cors@2.8.6:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
-    optional: true
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -14196,7 +13426,7 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  cosmiconfig@9.0.0(typescript@5.5.4):
+  cosmiconfig@9.0.1(typescript@5.5.4):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
@@ -14215,36 +13445,49 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-declaration-sorter@7.3.0(postcss@8.5.6):
+  css-declaration-sorter@7.3.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
-  css-loader@5.2.7(webpack@5.105.2):
+  css-loader@5.2.7(webpack@5.105.4):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
+      icss-utils: 5.1.0(postcss@8.5.8)
       loader-utils: 2.0.4
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
+      postcss: 8.5.8
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.8)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.8)
+      postcss-modules-scope: 3.2.1(postcss@8.5.8)
+      postcss-modules-values: 4.0.0(postcss@8.5.8)
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
-      semver: 7.7.3
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      semver: 7.7.4
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
-  css-loader@7.1.2(webpack@5.105.2):
+  css-loader@7.1.2(webpack@5.105.4):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
+      icss-utils: 5.1.0(postcss@8.5.2)
+      postcss: 8.5.2
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.2)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.2)
+      postcss-modules-scope: 3.2.1(postcss@8.5.2)
+      postcss-modules-values: 4.0.0(postcss@8.5.2)
       postcss-value-parser: 4.2.0
-      semver: 7.7.3
+      semver: 7.7.4
     optionalDependencies:
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
+
+  css-loader@7.1.4(webpack@5.105.4):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.8)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.8)
+      postcss-modules-scope: 3.2.1(postcss@8.5.8)
+      postcss-modules-values: 4.0.0(postcss@8.5.8)
+      postcss-value-parser: 4.2.0
+      semver: 7.7.4
+    optionalDependencies:
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
   css-select@5.2.2:
     dependencies:
@@ -14259,69 +13502,66 @@ snapshots:
       mdn-data: 2.0.28
       source-map-js: 1.2.1
 
-  css-tree@3.1.0:
+  css-tree@3.2.1:
     dependencies:
-      mdn-data: 2.12.2
+      mdn-data: 2.27.1
       source-map-js: 1.2.1
 
   css-what@6.2.2: {}
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-default@7.0.9(postcss@8.5.6):
+  cssnano-preset-default@7.0.11(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.1
-      css-declaration-sorter: 7.3.0(postcss@8.5.6)
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-calc: 10.1.1(postcss@8.5.6)
-      postcss-colormin: 7.0.4(postcss@8.5.6)
-      postcss-convert-values: 7.0.7(postcss@8.5.6)
-      postcss-discard-comments: 7.0.4(postcss@8.5.6)
-      postcss-discard-duplicates: 7.0.2(postcss@8.5.6)
-      postcss-discard-empty: 7.0.1(postcss@8.5.6)
-      postcss-discard-overridden: 7.0.1(postcss@8.5.6)
-      postcss-merge-longhand: 7.0.5(postcss@8.5.6)
-      postcss-merge-rules: 7.0.6(postcss@8.5.6)
-      postcss-minify-font-values: 7.0.1(postcss@8.5.6)
-      postcss-minify-gradients: 7.0.1(postcss@8.5.6)
-      postcss-minify-params: 7.0.4(postcss@8.5.6)
-      postcss-minify-selectors: 7.0.5(postcss@8.5.6)
-      postcss-normalize-charset: 7.0.1(postcss@8.5.6)
-      postcss-normalize-display-values: 7.0.1(postcss@8.5.6)
-      postcss-normalize-positions: 7.0.1(postcss@8.5.6)
-      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.6)
-      postcss-normalize-string: 7.0.1(postcss@8.5.6)
-      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.6)
-      postcss-normalize-unicode: 7.0.4(postcss@8.5.6)
-      postcss-normalize-url: 7.0.1(postcss@8.5.6)
-      postcss-normalize-whitespace: 7.0.1(postcss@8.5.6)
-      postcss-ordered-values: 7.0.2(postcss@8.5.6)
-      postcss-reduce-initial: 7.0.4(postcss@8.5.6)
-      postcss-reduce-transforms: 7.0.1(postcss@8.5.6)
-      postcss-svgo: 7.1.0(postcss@8.5.6)
-      postcss-unique-selectors: 7.0.4(postcss@8.5.6)
+      css-declaration-sorter: 7.3.1(postcss@8.5.8)
+      cssnano-utils: 5.0.1(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-calc: 10.1.1(postcss@8.5.8)
+      postcss-colormin: 7.0.6(postcss@8.5.8)
+      postcss-convert-values: 7.0.9(postcss@8.5.8)
+      postcss-discard-comments: 7.0.6(postcss@8.5.8)
+      postcss-discard-duplicates: 7.0.2(postcss@8.5.8)
+      postcss-discard-empty: 7.0.1(postcss@8.5.8)
+      postcss-discard-overridden: 7.0.1(postcss@8.5.8)
+      postcss-merge-longhand: 7.0.5(postcss@8.5.8)
+      postcss-merge-rules: 7.0.8(postcss@8.5.8)
+      postcss-minify-font-values: 7.0.1(postcss@8.5.8)
+      postcss-minify-gradients: 7.0.1(postcss@8.5.8)
+      postcss-minify-params: 7.0.6(postcss@8.5.8)
+      postcss-minify-selectors: 7.0.6(postcss@8.5.8)
+      postcss-normalize-charset: 7.0.1(postcss@8.5.8)
+      postcss-normalize-display-values: 7.0.1(postcss@8.5.8)
+      postcss-normalize-positions: 7.0.1(postcss@8.5.8)
+      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.8)
+      postcss-normalize-string: 7.0.1(postcss@8.5.8)
+      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.8)
+      postcss-normalize-unicode: 7.0.6(postcss@8.5.8)
+      postcss-normalize-url: 7.0.1(postcss@8.5.8)
+      postcss-normalize-whitespace: 7.0.1(postcss@8.5.8)
+      postcss-ordered-values: 7.0.2(postcss@8.5.8)
+      postcss-reduce-initial: 7.0.6(postcss@8.5.8)
+      postcss-reduce-transforms: 7.0.1(postcss@8.5.8)
+      postcss-svgo: 7.1.1(postcss@8.5.8)
+      postcss-unique-selectors: 7.0.5(postcss@8.5.8)
 
-  cssnano-utils@5.0.1(postcss@8.5.6):
+  cssnano-utils@5.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
-  cssnano@7.1.1(postcss@8.5.6):
+  cssnano@7.1.3(postcss@8.5.8):
     dependencies:
-      cssnano-preset-default: 7.0.9(postcss@8.5.6)
+      cssnano-preset-default: 7.0.11(postcss@8.5.8)
       lilconfig: 3.1.3
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   csso@5.0.5:
     dependencies:
       css-tree: 2.2.1
 
-  custom-event@1.0.1:
-    optional: true
-
   cypress@13.17.0:
     dependencies:
-      '@cypress/request': 3.0.9
+      '@cypress/request': 3.0.10
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.10
@@ -14332,12 +13572,12 @@ snapshots:
       cachedir: 2.4.0
       chalk: 4.1.2
       check-more-types: 2.24.0
-      ci-info: 4.3.1
+      ci-info: 4.4.0
       cli-cursor: 3.1.0
       cli-table3: 0.6.5
       commander: 6.2.1
       common-tags: 1.8.2
-      dayjs: 1.11.18
+      dayjs: 1.11.20
       debug: 4.4.3(supports-color@8.1.1)
       enquirer: 2.4.1
       eventemitter2: 6.4.7
@@ -14358,7 +13598,7 @@ snapshots:
       process: 0.11.10
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
-      semver: 7.7.3
+      semver: 7.7.4
       supports-color: 8.1.1
       tmp: 0.2.5
       tree-kill: 1.2.2
@@ -14371,10 +13611,7 @@ snapshots:
 
   date-fns@4.1.0: {}
 
-  date-format@4.0.14:
-    optional: true
-
-  dayjs@1.11.18: {}
+  dayjs@1.11.20: {}
 
   debug@2.6.9:
     dependencies:
@@ -14398,7 +13635,7 @@ snapshots:
 
   decamelize@4.0.0: {}
 
-  decode-named-character-reference@1.2.0:
+  decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
 
@@ -14408,7 +13645,7 @@ snapshots:
 
   default-browser-id@5.0.1: {}
 
-  default-browser@5.4.0:
+  default-browser@5.5.0:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
@@ -14431,9 +13668,6 @@ snapshots:
 
   destroy@1.2.0: {}
 
-  detect-libc@1.0.3:
-    optional: true
-
   detect-libc@2.1.2:
     optional: true
 
@@ -14443,9 +13677,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  di@0.0.1:
-    optional: true
-
   diff@4.0.4: {}
 
   diff@8.0.3: {}
@@ -14453,14 +13684,6 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
-
-  dom-serialize@2.2.1:
-    dependencies:
-      custom-event: 1.0.1
-      ent: 2.2.2
-      extend: 3.0.2
-      void-elements: 2.0.1
-    optional: true
 
   dom-serializer@2.0.0:
     dependencies:
@@ -14497,9 +13720,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.235: {}
-
-  electron-to-chromium@1.5.302: {}
+  electron-to-chromium@1.5.313: {}
 
   emoji-regex@10.6.0: {}
 
@@ -14508,8 +13729,6 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   emojis-list@3.0.0: {}
-
-  encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -14536,29 +13755,7 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.5:
-    dependencies:
-      '@types/cors': 2.8.19
-      '@types/node': 14.18.63
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cookie: 0.7.2
-      cors: 2.8.6
-      debug: 4.4.3(supports-color@8.1.1)
-      engine.io-parser: 5.2.3
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
-
-  enhanced-resolve@5.18.3:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.0
-
-  enhanced-resolve@5.19.0:
+  enhanced-resolve@5.20.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
@@ -14568,21 +13765,15 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
-  ent@2.2.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      punycode: 1.4.1
-      safe-regex-test: 1.1.0
-    optional: true
-
   entities@4.5.0: {}
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   env-paths@2.2.1: {}
 
-  envinfo@7.18.0: {}
+  envinfo@7.21.0: {}
 
   environment@1.1.0: {}
 
@@ -14601,8 +13792,6 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@1.7.0: {}
-
   es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
@@ -14618,44 +13807,44 @@ snapshots:
 
   es-toolkit@1.39.5: {}
 
-  esbuild-loader@4.4.0(webpack@5.105.2):
+  esbuild-loader@4.4.2(webpack@5.105.4):
     dependencies:
-      esbuild: 0.25.10
-      get-tsconfig: 4.12.0
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.6
       loader-utils: 2.0.4
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
       webpack-sources: 1.4.3
 
   esbuild-wasm@0.25.4: {}
 
-  esbuild@0.25.10:
+  esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.10
-      '@esbuild/android-arm': 0.25.10
-      '@esbuild/android-arm64': 0.25.10
-      '@esbuild/android-x64': 0.25.10
-      '@esbuild/darwin-arm64': 0.25.10
-      '@esbuild/darwin-x64': 0.25.10
-      '@esbuild/freebsd-arm64': 0.25.10
-      '@esbuild/freebsd-x64': 0.25.10
-      '@esbuild/linux-arm': 0.25.10
-      '@esbuild/linux-arm64': 0.25.10
-      '@esbuild/linux-ia32': 0.25.10
-      '@esbuild/linux-loong64': 0.25.10
-      '@esbuild/linux-mips64el': 0.25.10
-      '@esbuild/linux-ppc64': 0.25.10
-      '@esbuild/linux-riscv64': 0.25.10
-      '@esbuild/linux-s390x': 0.25.10
-      '@esbuild/linux-x64': 0.25.10
-      '@esbuild/netbsd-arm64': 0.25.10
-      '@esbuild/netbsd-x64': 0.25.10
-      '@esbuild/openbsd-arm64': 0.25.10
-      '@esbuild/openbsd-x64': 0.25.10
-      '@esbuild/openharmony-arm64': 0.25.10
-      '@esbuild/sunos-x64': 0.25.10
-      '@esbuild/win32-arm64': 0.25.10
-      '@esbuild/win32-ia32': 0.25.10
-      '@esbuild/win32-x64': 0.25.10
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.25.4:
     optionalDependencies:
@@ -14685,6 +13874,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.4
       '@esbuild/win32-x64': 0.25.4
 
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -14695,33 +13913,33 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-ckeditor5@13.0.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4):
+  eslint-config-ckeditor5@13.0.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4):
     dependencies:
-      '@eslint/js': 9.38.0
+      '@eslint/js': 9.39.4
       '@eslint/markdown': 6.6.0
-      '@stylistic/eslint-plugin': 4.4.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
-      eslint: 9.38.0(jiti@2.6.1)
-      eslint-plugin-ckeditor5-rules: 13.0.0
-      eslint-plugin-mocha: 11.2.0(eslint@9.38.0(jiti@2.6.1))
-      globals: 16.4.0
+      '@stylistic/eslint-plugin': 4.4.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-plugin-ckeditor5-rules: 13.0.1
+      eslint-plugin-mocha: 11.2.0(eslint@9.39.4(jiti@2.6.1))
+      globals: 16.5.0
       typescript: 5.5.4
-      typescript-eslint: 8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
+      typescript-eslint: 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-ckeditor5-rules@13.0.0:
+  eslint-plugin-ckeditor5-rules@13.0.1:
     dependencies:
       '@es-joy/jsdoccomment': 0.50.2
-      enhanced-resolve: 5.18.3
+      enhanced-resolve: 5.20.0
       resolve.exports: 2.0.3
       upath: 2.0.1
       validate-npm-package-name: 6.0.2
-      yaml: 2.8.1
+      yaml: 2.8.2
 
-  eslint-plugin-mocha@11.2.0(eslint@9.38.0(jiti@2.6.1)):
+  eslint-plugin-mocha@11.2.0(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
-      eslint: 9.38.0(jiti@2.6.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      eslint: 9.39.4(jiti@2.6.1)
       globals: 15.15.0
 
   eslint-scope@5.1.1:
@@ -14738,16 +13956,18 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.38.0(jiti@2.6.1):
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
-      '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.21.1
-      '@eslint/config-helpers': 0.4.1
-      '@eslint/core': 0.16.0
-      '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.38.0
-      '@eslint/plugin-kit': 0.4.0
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
@@ -14760,7 +13980,7 @@ snapshots:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
-      esquery: 1.6.0
+      esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 8.0.0
@@ -14771,7 +13991,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.3
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -14781,13 +14001,13 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
   esprima@4.0.1: {}
 
-  esquery@1.6.0:
+  esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
 
@@ -14823,7 +14043,7 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
-  eventemitter3@5.0.1: {}
+  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
@@ -14857,27 +14077,27 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
-  expect-type@1.2.2: {}
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
-  express@4.21.2:
+  express@4.22.1:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.3
+      body-parser: 1.20.4
       content-disposition: 0.5.4
       content-type: 1.0.5
-      cookie: 0.7.1
-      cookie-signature: 1.0.6
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
       debug: 2.6.9
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.1
+      finalhandler: 1.3.2
       fresh: 0.5.2
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       merge-descriptors: 1.0.3
       methods: 1.1.2
       on-finished: 2.4.1
@@ -14887,10 +14107,10 @@ snapshots:
       qs: 6.15.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.0
-      serve-static: 1.16.2
+      send: 0.19.2
+      serve-static: 1.16.3
       setprototypeof: 1.2.0
-      statuses: 2.0.1
+      statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
@@ -14933,16 +14153,18 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.0.0: {}
+  fast-xml-builder@1.1.3:
+    dependencies:
+      path-expression-matcher: 1.1.3
 
   fast-xml-parser@5.4.1:
     dependencies:
-      fast-xml-builder: 1.0.0
+      fast-xml-builder: 1.1.3
       strnum: 2.2.0
 
   fastest-levenshtein@1.0.16: {}
 
-  fastq@1.19.1:
+  fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
 
@@ -14957,6 +14179,10 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
+
+  fdir@6.5.0(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -14974,27 +14200,14 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.1.2:
-    dependencies:
-      debug: 2.6.9
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      on-finished: 2.3.0
-      parseurl: 1.3.3
-      statuses: 1.5.0
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  finalhandler@1.3.1:
+  finalhandler@1.3.2:
     dependencies:
       debug: 2.6.9
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
-      statuses: 2.0.1
+      statuses: 2.0.2
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
@@ -15027,12 +14240,12 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.1
       keyv: 4.5.4
 
   flat@5.0.2: {}
 
-  flatted@3.3.3: {}
+  flatted@3.4.1: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
@@ -15044,14 +14257,6 @@ snapshots:
       signal-exit: 4.1.0
 
   forever-agent@0.6.1: {}
-
-  form-data@4.0.4:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
 
   form-data@4.0.5:
     dependencies:
@@ -15077,13 +14282,6 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-extra@8.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-    optional: true
-
   fs-extra@9.1.0:
     dependencies:
       at-least-node: 1.0.0
@@ -15093,10 +14291,7 @@ snapshots:
 
   fs-minipass@3.0.3:
     dependencies:
-      minipass: 7.1.2
-
-  fs.realpath@1.0.0:
-    optional: true
+      minipass: 7.1.3
 
   fsevents@2.3.2:
     optional: true
@@ -15112,7 +14307,7 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.4.0: {}
+  get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -15136,11 +14331,11 @@ snapshots:
 
   get-stream@5.2.0:
     dependencies:
-      pump: 3.0.3
+      pump: 3.0.4
 
   get-stream@6.0.1: {}
 
-  get-tsconfig@4.12.0:
+  get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -15172,35 +14367,16 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.6
-      minipass: 7.1.2
+      minimatch: 9.0.9
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.1.0:
+  glob@13.0.6:
     dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.1.1
-      minimatch: 10.2.2
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
-
-  glob@13.0.0:
-    dependencies:
-      minimatch: 10.2.2
-      minipass: 7.1.2
-      path-scurry: 2.0.0
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.3
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    optional: true
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   global-dirs@3.0.1:
     dependencies:
@@ -15210,7 +14386,7 @@ snapshots:
 
   globals@15.15.0: {}
 
-  globals@16.4.0: {}
+  globals@16.5.0: {}
 
   globby@14.1.0:
     dependencies:
@@ -15224,8 +14400,6 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
-
-  graphemer@1.4.0: {}
 
   gray-matter@4.0.3:
     dependencies:
@@ -15277,7 +14451,7 @@ snapshots:
       hast-util-embedded: 3.0.0
       hast-util-is-element: 3.0.0
       hast-util-whitespace: 3.0.0
-      unist-util-is: 6.0.0
+      unist-util-is: 6.0.1
 
   hast-util-parse-selector@4.0.0:
     dependencies:
@@ -15355,7 +14529,7 @@ snapshots:
 
   hosted-git-info@9.0.2:
     dependencies:
-      lru-cache: 11.2.2
+      lru-cache: 11.2.7
 
   hpack.js@2.1.6:
     dependencies:
@@ -15375,23 +14549,23 @@ snapshots:
       domutils: 3.2.2
       entities: 6.0.1
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-cache-semantics@4.2.0: {}
 
   http-deceiver@1.2.7: {}
 
-  http-errors@1.6.3:
+  http-errors@1.8.1:
     dependencies:
       depd: 1.1.2
-      inherits: 2.0.3
-      setprototypeof: 1.1.0
-      statuses: 1.5.0
-
-  http-errors@2.0.0:
-    dependencies:
-      depd: 2.0.0
       inherits: 2.0.4
       setprototypeof: 1.2.0
-      statuses: 2.0.1
+      statuses: 1.5.0
       toidentifier: 1.0.1
 
   http-errors@2.0.1:
@@ -15401,7 +14575,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-    optional: true
 
   http-parser-js@0.5.10: {}
 
@@ -15412,21 +14585,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.23):
+  http-proxy-middleware@2.0.9(@types/express@4.17.25):
     dependencies:
-      '@types/http-proxy': 1.17.16
+      '@types/http-proxy': 1.17.17
       http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
     optionalDependencies:
-      '@types/express': 4.17.23
+      '@types/express': 4.17.25
     transitivePeerDependencies:
       - debug
 
   http-proxy-middleware@3.0.5:
     dependencies:
-      '@types/http-proxy': 1.17.16
+      '@types/http-proxy': 1.17.17
       debug: 4.4.3(supports-color@8.1.1)
       http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
@@ -15472,23 +14645,27 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iconv-lite@0.7.0:
+  iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.5.6):
+  icss-utils@5.1.0(postcss@8.5.2):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.2
+
+  icss-utils@5.1.0(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
 
   ieee754@1.2.1: {}
 
   ignore-walk@7.0.0:
     dependencies:
-      minimatch: 9.0.6
+      minimatch: 9.0.9
 
   ignore-walk@8.0.0:
     dependencies:
-      minimatch: 10.2.2
+      minimatch: 10.2.4
 
   ignore@5.3.2: {}
 
@@ -15497,7 +14674,7 @@ snapshots:
   image-size@0.5.5:
     optional: true
 
-  immutable@5.1.4: {}
+  immutable@5.1.5: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -15513,30 +14690,24 @@ snapshots:
 
   indent-string@4.0.0: {}
 
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-    optional: true
-
-  inherits@2.0.3: {}
-
   inherits@2.0.4: {}
 
   ini@2.0.0: {}
 
   ini@5.0.0: {}
 
-  injection-js@2.5.0:
+  ini@6.0.0: {}
+
+  injection-js@2.6.1:
     dependencies:
       tslib: 2.8.1
 
-  inquirer@12.10.0(@types/node@14.18.63):
+  inquirer@12.11.1(@types/node@14.18.63):
     dependencies:
-      '@inquirer/ansi': 1.0.1
-      '@inquirer/core': 10.3.0(@types/node@14.18.63)
-      '@inquirer/prompts': 7.9.0(@types/node@14.18.63)
-      '@inquirer/type': 3.0.9(@types/node@14.18.63)
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@14.18.63)
+      '@inquirer/prompts': 7.10.1(@types/node@14.18.63)
+      '@inquirer/type': 3.0.10(@types/node@14.18.63)
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
@@ -15545,11 +14716,11 @@ snapshots:
 
   interpret@3.1.1: {}
 
-  ip-address@10.0.1: {}
+  ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 
-  ipaddr.js@2.2.0: {}
+  ipaddr.js@2.3.0: {}
 
   is-arrayish@0.2.1: {}
 
@@ -15573,7 +14744,7 @@ snapshots:
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
-      get-east-asian-width: 1.4.0
+      get-east-asian-width: 1.5.0
 
   is-glob@4.0.3:
     dependencies:
@@ -15592,7 +14763,7 @@ snapshots:
 
   is-interactive@2.0.0: {}
 
-  is-network-error@1.3.0: {}
+  is-network-error@1.3.1: {}
 
   is-number@7.0.0: {}
 
@@ -15612,14 +14783,6 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
-  is-regex@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
-    optional: true
-
   is-regexp@1.0.0: {}
 
   is-stream@2.0.1: {}
@@ -15630,18 +14793,19 @@ snapshots:
 
   is-what@3.14.1: {}
 
-  is-wsl@3.1.0:
+  is-what@4.1.16: {}
+
+  is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
   isarray@1.0.0: {}
 
-  isbinaryfile@4.0.10:
-    optional: true
-
   isexe@2.0.0: {}
 
-  isexe@3.1.1: {}
+  isexe@3.1.5: {}
+
+  isexe@4.0.0: {}
 
   isobject@3.0.1: {}
 
@@ -15651,11 +14815,11 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/parser': 7.28.5
+      '@babel/core': 7.26.10
+      '@babel/parser': 7.29.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.3
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -15676,10 +14840,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jackspeak@4.1.1:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 14.18.63
@@ -15696,9 +14856,9 @@ snapshots:
       '@hapi/formula': 3.0.2
       '@hapi/hoek': 11.0.7
       '@hapi/pinpoint': 2.0.1
-      '@hapi/tlds': 1.1.3
+      '@hapi/tlds': 1.1.6
       '@hapi/topo': 6.0.2
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
 
   js-tokens@10.0.0: {}
 
@@ -15725,6 +14885,8 @@ snapshots:
 
   json-parse-even-better-errors@4.0.0: {}
 
+  json-parse-even-better-errors@5.0.0: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -15735,14 +14897,11 @@ snapshots:
 
   json-stringify-safe@5.0.1: {}
 
+  json-with-bigint@3.5.7: {}
+
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
-
-  jsonfile@4.0.0:
-    optionalDependencies:
-      graceful-fs: 4.2.11
-    optional: true
 
   jsonfile@6.2.0:
     dependencies:
@@ -15763,39 +14922,6 @@ snapshots:
     dependencies:
       source-map-support: 0.5.21
 
-  karma@6.4.4:
-    dependencies:
-      '@colors/colors': 1.5.0
-      body-parser: 1.20.4
-      braces: 3.0.3
-      chokidar: 3.6.0
-      connect: 3.7.0
-      di: 0.0.1
-      dom-serialize: 2.2.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      http-proxy: 1.18.1(debug@4.4.3)
-      isbinaryfile: 4.0.10
-      lodash: 4.17.23
-      log4js: 6.9.1
-      mime: 2.6.0
-      minimatch: 3.1.3
-      mkdirp: 0.5.6
-      qjobs: 1.2.0
-      range-parser: 1.2.1
-      rimraf: 3.0.2
-      socket.io: 4.8.3
-      source-map: 0.6.1
-      tmp: 0.2.5
-      ua-parser-js: 0.7.41
-      yargs: 16.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   keyux@0.7.2: {}
 
   keyv@4.5.4:
@@ -15806,18 +14932,18 @@ snapshots:
 
   klona@2.0.6: {}
 
-  launch-editor@2.11.1:
+  launch-editor@2.13.1:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
   lazy-ass@1.6.0: {}
 
-  less-loader@12.2.0(less@4.2.2)(webpack@5.105.2):
+  less-loader@12.2.0(less@4.2.2)(webpack@5.105.4):
     dependencies:
       less: 4.2.2
     optionalDependencies:
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
   less@4.2.2:
     dependencies:
@@ -15830,21 +14956,20 @@ snapshots:
       image-size: 0.5.5
       make-dir: 2.1.0
       mime: 1.6.0
-      needle: 3.3.1
+      needle: 3.5.0
       source-map: 0.6.1
 
-  less@4.4.2:
+  less@4.6.4:
     dependencies:
-      copy-anything: 2.0.6
+      copy-anything: 3.0.5
       parse-node-version: 1.0.1
-      tslib: 2.8.1
     optionalDependencies:
       errno: 0.1.8
       graceful-fs: 4.2.11
       image-size: 0.5.5
       make-dir: 2.1.0
       mime: 1.6.0
-      needle: 3.3.1
+      needle: 3.5.0
       source-map: 0.6.1
 
   levn@0.4.1:
@@ -15852,11 +14977,11 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.105.2):
+  license-webpack-plugin@4.0.2(webpack@5.105.4):
     dependencies:
-      webpack-sources: 3.3.3
+      webpack-sources: 3.3.4
     optionalDependencies:
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
   lilconfig@3.1.3: {}
 
@@ -15899,17 +15024,17 @@ snapshots:
     dependencies:
       cli-truncate: 4.0.0
       colorette: 2.0.20
-      eventemitter3: 5.0.1
+      eventemitter3: 5.0.4
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
   lmdb@3.2.6:
     dependencies:
-      msgpackr: 1.11.5
+      msgpackr: 1.11.9
       node-addon-api: 6.1.0
       node-gyp-build-optional-packages: 5.2.2
-      ordered-binary: 1.6.0
+      ordered-binary: 1.6.1
       weak-lru-cache: 1.2.2
     optionalDependencies:
       '@lmdb/lmdb-darwin-arm64': 3.2.6
@@ -15968,22 +15093,11 @@ snapshots:
 
   log-update@6.1.0:
     dependencies:
-      ansi-escapes: 7.2.0
+      ansi-escapes: 7.3.0
       cli-cursor: 5.0.0
       slice-ansi: 7.1.2
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
-
-  log4js@6.9.1:
-    dependencies:
-      date-format: 4.0.14
-      debug: 4.4.3(supports-color@8.1.1)
-      flatted: 3.3.3
-      rfdc: 1.4.1
-      streamroller: 3.1.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   long@5.3.2: {}
 
@@ -15991,7 +15105,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.2: {}
+  lru-cache@11.2.7: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -16007,10 +15121,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.5.1:
+  magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
   make-dir@2.1.0:
@@ -16025,7 +15139,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   make-error@1.3.6: {}
 
@@ -16034,7 +15148,7 @@ snapshots:
       '@npmcli/agent': 3.0.0
       cacache: 19.0.1
       http-cache-semantics: 4.2.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-fetch: 4.0.1
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
@@ -16045,19 +15159,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  make-fetch-happen@15.0.2:
+  make-fetch-happen@15.0.4:
     dependencies:
+      '@gar/promise-retry': 1.0.2
       '@npmcli/agent': 4.0.0
-      cacache: 20.0.1
+      cacache: 20.0.3
       http-cache-semantics: 4.2.0
-      minipass: 7.1.2
-      minipass-fetch: 4.0.1
+      minipass: 7.1.3
+      minipass-fetch: 5.0.2
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
       negotiator: 1.0.0
-      proc-log: 5.0.0
-      promise-retry: 2.0.1
-      ssri: 12.0.0
+      proc-log: 6.1.0
+      ssri: 13.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -16071,14 +15185,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       escape-string-regexp: 5.0.0
-      unist-util-is: 6.0.0
-      unist-util-visit-parents: 6.0.1
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.2:
+  mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
-      decode-named-character-reference: 1.2.0
+      decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
       micromark: 4.0.2
@@ -16096,7 +15210,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -16114,7 +15228,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
@@ -16123,7 +15237,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -16133,7 +15247,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -16142,14 +15256,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -16167,7 +15281,7 @@ snapshots:
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
-      unist-util-is: 6.0.0
+      unist-util-is: 6.0.1
 
   mdast-util-to-hast@13.2.1:
     dependencies:
@@ -16190,7 +15304,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   mdast-util-to-string@4.0.0:
@@ -16199,12 +15313,20 @@ snapshots:
 
   mdn-data@2.0.28: {}
 
-  mdn-data@2.12.2: {}
+  mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
 
-  memfs@4.51.0:
+  memfs@4.56.11(tslib@2.8.1):
     dependencies:
+      '@jsonjoy.com/fs-core': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-fsa': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-node': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-to-fsa': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.56.11(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.56.11(tslib@2.8.1)
       '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
       '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
       glob-to-regex.js: 1.2.0(tslib@2.8.1)
@@ -16222,7 +15344,7 @@ snapshots:
 
   micromark-core-commonmark@2.0.3:
     dependencies:
-      decode-named-character-reference: 1.2.0
+      decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-factory-destination: 2.0.1
       micromark-factory-label: 2.0.1
@@ -16362,7 +15484,7 @@ snapshots:
 
   micromark-util-decode-string@2.0.1:
     dependencies:
-      decode-named-character-reference: 1.2.0
+      decode-named-character-reference: 1.3.0
       micromark-util-character: 2.1.1
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-symbol: 2.0.1
@@ -16400,7 +15522,7 @@ snapshots:
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.4.3(supports-color@8.1.1)
-      decode-named-character-reference: 1.2.0
+      decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-factory-space: 2.0.1
@@ -16433,52 +15555,57 @@ snapshots:
 
   mime@1.6.0: {}
 
-  mime@2.6.0:
-    optional: true
-
   mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.105.2):
+  mini-css-extract-plugin@2.10.1(webpack@5.105.4):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.2):
+  mini-css-extract-plugin@2.9.2(webpack@5.105.4):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
   minimalistic-assert@1.0.1: {}
 
-  minimatch@10.2.2:
+  minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.3
+      brace-expansion: 5.0.4
 
-  minimatch@3.1.3:
+  minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@9.0.6:
+  minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.3
+      brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
 
   minipass-collect@2.0.1:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   minipass-fetch@4.0.1:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-sized: 1.0.3
       minizlib: 3.1.0
     optionalDependencies:
       encoding: 0.1.13
+
+  minipass-fetch@5.0.2:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 2.0.0
+      minizlib: 3.1.0
+    optionalDependencies:
+      iconv-lite: 0.7.2
 
   minipass-flush@1.0.5:
     dependencies:
@@ -16492,24 +15619,23 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  minipass-sized@2.0.0:
+    dependencies:
+      minipass: 7.1.3
+
   minipass@3.3.6:
     dependencies:
       yallist: 4.0.0
 
-  minipass@7.1.2: {}
+  minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.2
-
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
-    optional: true
+      minipass: 7.1.3
 
   mkdirp@3.0.1: {}
 
-  mocha@11.7.4:
+  mocha@11.7.5:
     dependencies:
       browser-stdout: 1.3.1
       chokidar: 4.0.3
@@ -16522,7 +15648,7 @@ snapshots:
       is-path-inside: 3.0.3
       js-yaml: 4.1.1
       log-symbols: 4.1.0
-      minimatch: 9.0.6
+      minimatch: 9.0.9
       ms: 2.1.3
       picocolors: 1.1.1
       serialize-javascript: 6.0.2
@@ -16553,7 +15679,7 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
     optional: true
 
-  msgpackr@1.11.5:
+  msgpackr@1.11.9:
     optionalDependencies:
       msgpackr-extract: 3.0.3
     optional: true
@@ -16571,10 +15697,10 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  needle@3.3.1:
+  needle@3.5.0:
     dependencies:
       iconv-lite: 0.6.3
-      sax: 1.4.1
+      sax: 1.5.0
     optional: true
 
   negotiator@0.6.3: {}
@@ -16585,29 +15711,29 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  ng-packagr@19.2.2(@angular/compiler-cli@19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4):
+  ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4):
     dependencies:
-      '@angular/compiler-cli': 19.2.19(@angular/compiler@19.2.19)(typescript@5.5.4)
+      '@angular/compiler-cli': 19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4)
       '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
-      '@rollup/wasm-node': 4.53.2
+      '@rollup/wasm-node': 4.59.0
       ajv: 8.18.0
       ansi-colors: 4.1.3
-      browserslist: 4.26.3
+      browserslist: 4.28.1
       chokidar: 4.0.3
       commander: 13.1.0
       convert-source-map: 2.0.0
       dependency-graph: 1.0.0
-      esbuild: 0.25.10
+      esbuild: 0.25.12
       fast-glob: 3.3.3
       find-cache-dir: 3.3.2
-      injection-js: 2.5.0
+      injection-js: 2.6.1
       jsonc-parser: 3.3.1
-      less: 4.4.2
+      less: 4.6.4
       ora: 5.4.1
       piscina: 4.9.2
-      postcss: 8.5.6
+      postcss: 8.5.8
       rxjs: 7.8.2
-      sass: 1.93.2
+      sass: 1.98.0
       tslib: 2.8.1
       typescript: 5.5.4
     optionalDependencies:
@@ -16626,7 +15752,7 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
-  node-gyp@11.4.2:
+  node-gyp@11.5.0:
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.3
@@ -16634,20 +15760,37 @@ snapshots:
       make-fetch-happen: 14.0.3
       nopt: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.3
-      tar: 7.5.9
+      semver: 7.7.4
+      tar: 7.5.11
       tinyglobby: 0.2.15
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  node-releases@2.0.23: {}
+  node-gyp@12.2.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 15.0.4
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.7.4
+      tar: 7.5.11
+      tinyglobby: 0.2.15
+      which: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
 
-  node-releases@2.0.27: {}
+  node-releases@2.0.36: {}
 
   nopt@8.1.0:
     dependencies:
       abbrev: 3.0.1
+
+  nopt@9.0.0:
+    dependencies:
+      abbrev: 4.0.0
 
   normalize-path@3.0.0: {}
 
@@ -16657,30 +15800,40 @@ snapshots:
     dependencies:
       npm-normalize-package-bin: 4.0.0
 
+  npm-bundled@5.0.0:
+    dependencies:
+      npm-normalize-package-bin: 5.0.0
+
   npm-install-checks@7.1.2:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
+
+  npm-install-checks@8.0.0:
+    dependencies:
+      semver: 7.7.4
 
   npm-normalize-package-bin@4.0.0: {}
+
+  npm-normalize-package-bin@5.0.0: {}
 
   npm-package-arg@12.0.2:
     dependencies:
       hosted-git-info: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.3
+      semver: 7.7.4
       validate-npm-package-name: 6.0.2
 
-  npm-package-arg@13.0.1:
+  npm-package-arg@13.0.2:
     dependencies:
       hosted-git-info: 9.0.2
-      proc-log: 5.0.0
-      semver: 7.7.3
-      validate-npm-package-name: 6.0.2
+      proc-log: 6.1.0
+      semver: 7.7.4
+      validate-npm-package-name: 7.0.2
 
-  npm-packlist@10.0.2:
+  npm-packlist@10.0.4:
     dependencies:
       ignore-walk: 8.0.0
-      proc-log: 5.0.0
+      proc-log: 6.1.0
 
   npm-packlist@9.0.0:
     dependencies:
@@ -16691,21 +15844,21 @@ snapshots:
       npm-install-checks: 7.1.2
       npm-normalize-package-bin: 4.0.0
       npm-package-arg: 12.0.2
-      semver: 7.7.3
+      semver: 7.7.4
 
-  npm-pick-manifest@11.0.1:
+  npm-pick-manifest@11.0.3:
     dependencies:
-      npm-install-checks: 7.1.2
-      npm-normalize-package-bin: 4.0.0
-      npm-package-arg: 13.0.1
-      semver: 7.7.3
+      npm-install-checks: 8.0.0
+      npm-normalize-package-bin: 5.0.0
+      npm-package-arg: 13.0.2
+      semver: 7.7.4
 
   npm-registry-fetch@18.0.2:
     dependencies:
       '@npmcli/redact': 3.2.2
       jsonparse: 1.3.1
       make-fetch-happen: 14.0.3
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-fetch: 4.0.1
       minizlib: 3.1.0
       npm-package-arg: 12.0.2
@@ -16713,16 +15866,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  npm-registry-fetch@19.0.0:
+  npm-registry-fetch@19.1.1:
     dependencies:
-      '@npmcli/redact': 3.2.2
+      '@npmcli/redact': 4.0.0
       jsonparse: 1.3.1
-      make-fetch-happen: 15.0.2
-      minipass: 7.1.2
-      minipass-fetch: 4.0.1
+      make-fetch-happen: 15.0.4
+      minipass: 7.1.3
+      minipass-fetch: 5.0.2
       minizlib: 3.1.0
-      npm-package-arg: 13.0.1
-      proc-log: 5.0.0
+      npm-package-arg: 13.0.2
+      proc-log: 6.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16734,19 +15887,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  object-assign@4.1.1:
-    optional: true
-
   object-inspect@1.13.4: {}
 
   obuf@1.1.2: {}
 
   obug@2.1.1: {}
-
-  on-finished@2.3.0:
-    dependencies:
-      ee-first: 1.1.1
-    optional: true
 
   on-finished@2.4.1:
     dependencies:
@@ -16768,10 +15913,10 @@ snapshots:
 
   open@10.1.0:
     dependencies:
-      default-browser: 5.4.0
+      default-browser: 5.5.0
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
-      is-wsl: 3.1.0
+      is-wsl: 3.1.1
 
   optionator@0.9.4:
     dependencies:
@@ -16794,7 +15939,7 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
-  ordered-binary@1.6.0:
+  ordered-binary@1.6.1:
     optional: true
 
   ospath@1.2.2: {}
@@ -16809,7 +15954,7 @@ snapshots:
 
   p-limit@4.0.0:
     dependencies:
-      yocto-queue: 1.2.1
+      yocto-queue: 1.2.2
 
   p-locate@4.1.0:
     dependencies:
@@ -16827,12 +15972,12 @@ snapshots:
     dependencies:
       aggregate-error: 3.1.0
 
-  p-map@7.0.3: {}
+  p-map@7.0.4: {}
 
   p-retry@6.2.1:
     dependencies:
       '@types/retry': 0.12.2
-      is-network-error: 1.3.0
+      is-network-error: 1.3.1
       retry: 0.13.1
 
   p-try@2.2.0: {}
@@ -16848,7 +15993,7 @@ snapshots:
       '@npmcli/run-script': 9.1.0
       cacache: 19.0.1
       fs-minipass: 3.0.3
-      minipass: 7.1.2
+      minipass: 7.1.3
       npm-package-arg: 12.0.2
       npm-packlist: 9.0.0
       npm-pick-manifest: 10.0.0
@@ -16857,29 +16002,29 @@ snapshots:
       promise-retry: 2.0.1
       sigstore: 3.1.0
       ssri: 12.0.0
-      tar: 7.5.9
+      tar: 7.5.11
     transitivePeerDependencies:
       - supports-color
 
-  pacote@21.0.3:
+  pacote@21.5.0:
     dependencies:
-      '@npmcli/git': 7.0.0
-      '@npmcli/installed-package-contents': 3.0.0
-      '@npmcli/package-json': 7.0.1
-      '@npmcli/promise-spawn': 8.0.3
-      '@npmcli/run-script': 10.0.0
-      cacache: 20.0.1
+      '@gar/promise-retry': 1.0.2
+      '@npmcli/git': 7.0.2
+      '@npmcli/installed-package-contents': 4.0.0
+      '@npmcli/package-json': 7.0.5
+      '@npmcli/promise-spawn': 9.0.1
+      '@npmcli/run-script': 10.0.4
+      cacache: 20.0.3
       fs-minipass: 3.0.3
-      minipass: 7.1.2
-      npm-package-arg: 13.0.1
-      npm-packlist: 10.0.2
-      npm-pick-manifest: 11.0.1
-      npm-registry-fetch: 19.0.0
-      proc-log: 5.0.0
-      promise-retry: 2.0.1
-      sigstore: 4.0.0
-      ssri: 12.0.0
-      tar: 7.5.9
+      minipass: 7.1.3
+      npm-package-arg: 13.0.2
+      npm-packlist: 10.0.4
+      npm-pick-manifest: 11.0.3
+      npm-registry-fetch: 19.1.1
+      proc-log: 6.1.0
+      sigstore: 4.1.0
+      ssri: 13.0.1
+      tar: 7.5.11
     transitivePeerDependencies:
       - supports-color
 
@@ -16889,7 +16034,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -16918,8 +16063,7 @@ snapshots:
 
   path-exists@5.0.0: {}
 
-  path-is-absolute@1.0.1:
-    optional: true
+  path-expression-matcher@1.1.3: {}
 
   path-key@3.1.1: {}
 
@@ -16928,12 +16072,12 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
-  path-scurry@2.0.0:
+  path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.2
-      minipass: 7.1.2
+      lru-cache: 11.2.7
+      minipass: 7.1.3
 
   path-to-regexp@0.1.12: {}
 
@@ -16972,10 +16116,6 @@ snapshots:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
 
-  pixelmatch@7.1.0:
-    dependencies:
-      pngjs: 7.0.0
-
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
@@ -17002,245 +16142,266 @@ snapshots:
 
   pofile@1.1.4: {}
 
-  postcss-calc@10.1.1(postcss@8.5.6):
+  postcss-calc@10.1.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
-      postcss-selector-parser: 7.1.0
+      postcss: 8.5.8
+      postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@7.0.4(postcss@8.5.6):
+  postcss-colormin@7.0.6(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@7.0.7(postcss@8.5.6):
+  postcss-convert-values@7.0.9(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.1
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-discard-comments@7.0.4(postcss@8.5.6):
+  postcss-discard-comments@7.0.6(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
-      postcss-selector-parser: 7.1.0
+      postcss: 8.5.8
+      postcss-selector-parser: 7.1.1
 
-  postcss-discard-duplicates@7.0.2(postcss@8.5.6):
+  postcss-discard-duplicates@7.0.2(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
-  postcss-discard-empty@7.0.1(postcss@8.5.6):
+  postcss-discard-empty@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
-  postcss-discard-overridden@7.0.1(postcss@8.5.6):
+  postcss-discard-overridden@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
-  postcss-import@16.1.1(postcss@8.5.6):
+  postcss-import@16.1.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
-      resolve: 1.22.10
+      resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.5.6):
+  postcss-js@4.1.0(postcss@8.5.8):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.6
+      postcss: 8.5.8
 
-  postcss-loader@4.3.0(postcss@8.5.6)(webpack@5.105.2):
+  postcss-loader@4.3.0(postcss@8.5.8)(webpack@5.105.4):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
       loader-utils: 2.0.4
-      postcss: 8.5.6
+      postcss: 8.5.8
       schema-utils: 3.3.0
-      semver: 7.7.3
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      semver: 7.7.4
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
-  postcss-loader@8.1.1(postcss@8.5.2)(typescript@5.5.4)(webpack@5.105.2):
+  postcss-loader@8.1.1(postcss@8.5.2)(typescript@5.5.4)(webpack@5.105.4):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.5.4)
+      cosmiconfig: 9.0.1(typescript@5.5.4)
       jiti: 1.21.7
       postcss: 8.5.2
-      semver: 7.7.3
+      semver: 7.7.4
     optionalDependencies:
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
 
-  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.5.4)(webpack@5.105.2):
+  postcss-loader@8.2.1(postcss@8.5.8)(typescript@5.5.4)(webpack@5.105.4):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.5.4)
+      cosmiconfig: 9.0.1(typescript@5.5.4)
       jiti: 2.6.1
-      postcss: 8.5.6
-      semver: 7.7.3
+      postcss: 8.5.8
+      semver: 7.7.4
     optionalDependencies:
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
 
   postcss-media-query-parser@0.2.3: {}
 
-  postcss-merge-longhand@7.0.5(postcss@8.5.6):
+  postcss-merge-longhand@7.0.5(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
-      stylehacks: 7.0.6(postcss@8.5.6)
+      stylehacks: 7.0.8(postcss@8.5.8)
 
-  postcss-merge-rules@7.0.6(postcss@8.5.6):
+  postcss-merge-rules@7.0.8(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-selector-parser: 7.1.0
+      cssnano-utils: 5.0.1(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-selector-parser: 7.1.1
 
-  postcss-minify-font-values@7.0.1(postcss@8.5.6):
+  postcss-minify-font-values@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@7.0.1(postcss@8.5.6):
+  postcss-minify-gradients@7.0.1(postcss@8.5.8):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.8)
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@7.0.4(postcss@8.5.6):
+  postcss-minify-params@7.0.6(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.1
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.8)
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@7.0.5(postcss@8.5.6):
+  postcss-minify-selectors@7.0.6(postcss@8.5.8):
     dependencies:
       cssesc: 3.0.0
-      postcss: 8.5.6
-      postcss-selector-parser: 7.1.0
+      postcss: 8.5.8
+      postcss-selector-parser: 7.1.1
 
-  postcss-mixins@11.0.3(postcss@8.5.6):
+  postcss-mixins@11.0.3(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
-      postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-simple-vars: 7.0.1(postcss@8.5.6)
-      sugarss: 4.0.1(postcss@8.5.6)
+      postcss: 8.5.8
+      postcss-js: 4.1.0(postcss@8.5.8)
+      postcss-simple-vars: 7.0.1(postcss@8.5.8)
+      sugarss: 4.0.1(postcss@8.5.8)
       tinyglobby: 0.2.15
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.2):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.2
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.6):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.8):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-selector-parser: 7.1.0
+      postcss: 8.5.8
+
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.2):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.2)
+      postcss: 8.5.2
+      postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.6):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
-      postcss-selector-parser: 7.1.0
-
-  postcss-modules-values@4.0.0(postcss@8.5.6):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-
-  postcss-nesting@13.0.2(postcss@8.5.6):
-    dependencies:
-      '@csstools/selector-resolve-nested': 3.1.0(postcss-selector-parser@7.1.0)
-      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.0)
-      postcss: 8.5.6
-      postcss-selector-parser: 7.1.0
-
-  postcss-normalize-charset@7.0.1(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
-
-  postcss-normalize-display-values@7.0.1(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
+      icss-utils: 5.1.0(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@7.0.1(postcss@8.5.6):
+  postcss-modules-scope@3.2.1(postcss@8.5.2):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.2
+      postcss-selector-parser: 7.1.1
+
+  postcss-modules-scope@3.2.1(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+      postcss-selector-parser: 7.1.1
+
+  postcss-modules-values@4.0.0(postcss@8.5.2):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.2)
+      postcss: 8.5.2
+
+  postcss-modules-values@4.0.0(postcss@8.5.8):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.8)
+      postcss: 8.5.8
+
+  postcss-nesting@13.0.2(postcss@8.5.8):
+    dependencies:
+      '@csstools/selector-resolve-nested': 3.1.0(postcss-selector-parser@7.1.1)
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
+      postcss: 8.5.8
+      postcss-selector-parser: 7.1.1
+
+  postcss-normalize-charset@7.0.1(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+
+  postcss-normalize-display-values@7.0.1(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@7.0.1(postcss@8.5.6):
+  postcss-normalize-positions@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@7.0.1(postcss@8.5.6):
+  postcss-normalize-repeat-style@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@7.0.1(postcss@8.5.6):
+  postcss-normalize-string@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@7.0.4(postcss@8.5.6):
+  postcss-normalize-timing-functions@7.0.1(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-unicode@7.0.6(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.1
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@7.0.1(postcss@8.5.6):
+  postcss-normalize-url@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@7.0.1(postcss@8.5.6):
+  postcss-normalize-whitespace@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-ordered-values@7.0.2(postcss@8.5.6):
+  postcss-ordered-values@7.0.2(postcss@8.5.8):
     dependencies:
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.8)
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@7.0.4(postcss@8.5.6):
+  postcss-reduce-initial@7.0.6(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
-      postcss: 8.5.6
+      postcss: 8.5.8
 
-  postcss-reduce-transforms@7.0.1(postcss@8.5.6):
+  postcss-reduce-transforms@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  postcss-selector-parser@7.1.0:
+  postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-simple-vars@7.0.1(postcss@8.5.6):
+  postcss-simple-vars@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
-  postcss-svgo@7.1.0(postcss@8.5.6):
+  postcss-svgo@7.1.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
-      svgo: 4.0.0
+      svgo: 4.0.1
 
-  postcss-unique-selectors@7.0.4(postcss@8.5.6):
+  postcss-unique-selectors@7.0.5(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
-      postcss-selector-parser: 7.1.0
+      postcss: 8.5.8
+      postcss-selector-parser: 7.1.1
 
   postcss-value-parser@4.2.0: {}
 
@@ -17250,7 +16411,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.6:
+  postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -17261,6 +16422,8 @@ snapshots:
   pretty-bytes@5.6.0: {}
 
   proc-log@5.0.0: {}
+
+  proc-log@6.1.0: {}
 
   process-nextick-args@2.0.1: {}
 
@@ -17304,18 +16467,16 @@ snapshots:
     dependencies:
       event-stream: 3.3.4
 
-  pump@3.0.3:
+  pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  punycode@1.4.1:
-    optional: true
-
   punycode@2.3.1: {}
 
-  qjobs@1.2.0:
-    optional: true
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
 
   qs@6.15.0:
     dependencies:
@@ -17331,26 +16492,18 @@ snapshots:
 
   range-parser@1.2.1: {}
 
-  raw-body@2.5.2:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.4.24
-      unpipe: 1.0.0
-
   raw-body@2.5.3:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       unpipe: 1.0.0
-    optional: true
 
-  raw-loader@4.0.2(webpack@5.105.2):
+  raw-loader@4.0.2(webpack@5.105.4):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
   read-cache@1.0.0:
     dependencies:
@@ -17380,7 +16533,7 @@ snapshots:
 
   rechoir@0.8.0:
     dependencies:
-      resolve: 1.22.10
+      resolve: 1.22.11
 
   reflect-metadata@0.2.2: {}
 
@@ -17454,7 +16607,7 @@ snapshots:
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -17499,12 +16652,18 @@ snapshots:
       adjust-sourcemap-loader: 4.0.0
       convert-source-map: 1.9.0
       loader-utils: 2.0.4
-      postcss: 8.5.6
+      postcss: 8.5.2
       source-map: 0.6.1
 
   resolve.exports@2.0.3: {}
 
   resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
       path-parse: 1.0.7
@@ -17528,14 +16687,9 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rimraf@3.0.2:
+  rimraf@6.1.3:
     dependencies:
-      glob: 7.2.3
-    optional: true
-
-  rimraf@6.0.1:
-    dependencies:
-      glob: 11.1.0
+      glob: 13.0.6
       package-json-from-dist: 1.0.1
 
   rollup@4.59.0:
@@ -17593,39 +16747,32 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  safe-regex-test@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-regex: 1.2.1
-    optional: true
-
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.85.0)(webpack@5.105.2):
+  sass-loader@16.0.5(sass@1.85.0)(webpack@5.105.4):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.85.0
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
   sass@1.85.0:
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.4
+      immutable: 5.1.5
       source-map-js: 1.2.1
     optionalDependencies:
-      '@parcel/watcher': 2.5.1
+      '@parcel/watcher': 2.5.6
 
-  sass@1.93.2:
+  sass@1.98.0:
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.4
+      immutable: 5.1.5
       source-map-js: 1.2.1
     optionalDependencies:
-      '@parcel/watcher': 2.5.1
+      '@parcel/watcher': 2.5.6
 
-  sax@1.4.1: {}
+  sax@1.5.0: {}
 
   schema-utils@3.3.0:
     dependencies:
@@ -17661,23 +16808,23 @@ snapshots:
 
   semver@7.7.1: {}
 
-  semver@7.7.3: {}
+  semver@7.7.4: {}
 
-  send@0.19.0:
+  send@0.19.2:
     dependencies:
       debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
-      encodeurl: 1.0.2
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
       fresh: 0.5.2
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       mime: 1.6.0
       ms: 2.1.3
       on-finished: 2.4.1
       range-parser: 1.2.1
-      statuses: 2.0.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17685,28 +16832,26 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  serve-index@1.9.1:
+  serve-index@1.9.2:
     dependencies:
       accepts: 1.3.8
       batch: 0.6.1
       debug: 2.6.9
       escape-html: 1.0.3
-      http-errors: 1.6.3
+      http-errors: 1.8.1
       mime-types: 2.1.35
       parseurl: 1.3.3
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.2:
+  serve-static@1.16.3:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.0
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
-
-  setprototypeof@1.1.0: {}
 
   setprototypeof@1.2.0: {}
 
@@ -17774,18 +16919,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  sigstore@4.0.0:
+  sigstore@4.1.0:
     dependencies:
       '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.0.0
+      '@sigstore/core': 3.1.0
       '@sigstore/protobuf-specs': 0.5.0
-      '@sigstore/sign': 4.0.1
-      '@sigstore/tuf': 4.0.0
-      '@sigstore/verify': 3.0.0
+      '@sigstore/sign': 4.1.0
+      '@sigstore/tuf': 4.0.1
+      '@sigstore/verify': 3.1.0
     transitivePeerDependencies:
       - supports-color
 
-  simple-git@3.28.0:
+  simple-git@3.33.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
@@ -17827,16 +16972,6 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socket.io-adapter@2.5.6:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   socket.io-client@4.7.0:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -17855,21 +16990,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@4.8.3:
-    dependencies:
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cors: 2.8.6
-      debug: 4.4.3(supports-color@8.1.1)
-      engine.io: 6.6.5
-      socket.io-adapter: 2.5.6
-      socket.io-parser: 4.2.5
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
@@ -17886,18 +17006,18 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.0.1
+      ip-address: 10.1.0
       smart-buffer: 4.2.0
 
   source-list-map@2.0.1: {}
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.2):
+  source-map-loader@5.0.0(webpack@5.105.4):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
   source-map-support@0.5.21:
     dependencies:
@@ -17915,16 +17035,21 @@ snapshots:
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.22
+      spdx-license-ids: 3.0.23
 
   spdx-exceptions@2.5.0: {}
 
   spdx-expression-parse@3.0.1:
     dependencies:
       spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.22
+      spdx-license-ids: 3.0.23
 
-  spdx-license-ids@3.0.22: {}
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   spdy-transport@3.0.0:
     dependencies:
@@ -17969,7 +17094,11 @@ snapshots:
 
   ssri@12.0.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
+
+  ssri@13.0.1:
+    dependencies:
+      minipass: 7.1.3
 
   stackback@0.0.2: {}
 
@@ -17988,25 +17117,13 @@ snapshots:
 
   statuses@1.5.0: {}
 
-  statuses@2.0.1: {}
+  statuses@2.0.2: {}
 
-  statuses@2.0.2:
-    optional: true
-
-  std-env@3.10.0: {}
+  std-env@4.0.0: {}
 
   stream-combiner@0.0.4:
     dependencies:
       duplexer: 0.1.2
-
-  streamroller@3.1.5:
-    dependencies:
-      date-format: 4.0.14
-      debug: 4.4.3(supports-color@8.1.1)
-      fs-extra: 8.1.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   string-argv@0.3.1: {}
 
@@ -18020,13 +17137,13 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.4.0
-      strip-ansi: 7.1.2
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
 
   string_decoder@1.1.1:
     dependencies:
@@ -18051,7 +17168,7 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.1.2:
+  strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
 
@@ -18063,27 +17180,27 @@ snapshots:
 
   strnum@2.2.0: {}
 
-  style-loader@2.0.0(webpack@5.105.2):
+  style-loader@2.0.0(webpack@5.105.4):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
-  style-loader@4.0.0(webpack@5.105.2):
+  style-loader@4.0.0(webpack@5.105.4):
     dependencies:
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
-  style-mod@4.1.2: {}
+  style-mod@4.1.3: {}
 
-  stylehacks@7.0.6(postcss@8.5.6):
+  stylehacks@7.0.8(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.1
-      postcss: 8.5.6
-      postcss-selector-parser: 7.1.0
+      postcss: 8.5.8
+      postcss-selector-parser: 7.1.1
 
-  sugarss@4.0.1(postcss@8.5.6):
+  sugarss@4.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   supports-color@7.2.0:
     dependencies:
@@ -18095,50 +17212,49 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svgo@4.0.0:
+  svgo@4.0.1:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
-      sax: 1.4.1
+      sax: 1.5.0
 
   symbol-observable@4.0.0: {}
 
   tapable@2.3.0: {}
 
-  tar@7.5.9:
+  tar@7.5.11:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  terser-webpack-plugin@5.3.16(esbuild@0.25.4)(webpack@5.105.2):
+  terser-webpack-plugin@5.4.0(esbuild@0.25.4)(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.44.0
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      terser: 5.46.0
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
     optionalDependencies:
       esbuild: 0.25.4
 
   terser@5.39.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  terser@5.44.0:
+  terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -18158,14 +17274,14 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.2: {}
+  tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinyrainbow@3.0.3: {}
+  tinyrainbow@3.1.0: {}
 
   tldts-core@6.1.86: {}
 
@@ -18199,19 +17315,19 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.1.0(typescript@5.5.4):
+  ts-api-utils@2.4.0(typescript@5.5.4):
     dependencies:
       typescript: 5.5.4
 
-  ts-loader@9.5.4(typescript@5.5.4)(webpack@5.105.2):
+  ts-loader@9.5.4(typescript@5.5.4)(webpack@5.105.4):
     dependencies:
       chalk: 4.1.2
-      enhanced-resolve: 5.18.3
+      enhanced-resolve: 5.20.0
       micromatch: 4.0.8
-      semver: 7.7.3
+      semver: 7.7.4
       source-map: 0.7.6
       typescript: 5.5.4
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
   ts-morph@21.0.1:
     dependencies:
@@ -18240,11 +17356,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  tuf-js@4.0.0:
+  tuf-js@4.1.0:
     dependencies:
-      '@tufjs/models': 4.0.0
+      '@tufjs/models': 4.1.0
       debug: 4.4.3(supports-color@8.1.1)
-      make-fetch-happen: 15.0.2
+      make-fetch-happen: 15.0.4
     transitivePeerDependencies:
       - supports-color
 
@@ -18267,21 +17383,18 @@ snapshots:
 
   typed-assert@1.0.9: {}
 
-  typescript-eslint@8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4):
+  typescript-eslint@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.1(@typescript-eslint/parser@8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4))(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
-      '@typescript-eslint/parser': 8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
-      '@typescript-eslint/typescript-estree': 8.46.1(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.5.4)
-      eslint: 9.38.0(jiti@2.6.1)
+      '@typescript-eslint/eslint-plugin': 8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4))(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.5.4)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.5.4: {}
-
-  ua-parser-js@0.7.41:
-    optional: true
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -18310,16 +17423,24 @@ snapshots:
     dependencies:
       unique-slug: 5.0.0
 
+  unique-filename@5.0.0:
+    dependencies:
+      unique-slug: 6.0.0
+
   unique-slug@5.0.0:
+    dependencies:
+      imurmurhash: 0.1.4
+
+  unique-slug@6.0.0:
     dependencies:
       imurmurhash: 0.1.4
 
   unist-util-find-after@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
+      unist-util-is: 6.0.1
 
-  unist-util-is@6.0.0:
+  unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
 
@@ -18331,21 +17452,24 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  unist-util-visit-parents@6.0.1:
+  unist-util-visit-parents@6.0.2:
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
+      unist-util-is: 6.0.1
 
   unist-util-visit@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
-      unist-util-visit-parents: 6.0.1
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   universal-user-agent@7.0.3: {}
-
-  universalify@0.1.2:
-    optional: true
 
   universalify@2.0.1: {}
 
@@ -18354,12 +17478,6 @@ snapshots:
   untildify@4.0.0: {}
 
   upath@2.0.1: {}
-
-  update-browserslist-db@1.1.3(browserslist@4.26.3):
-    dependencies:
-      browserslist: 4.26.3
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -18391,6 +17509,8 @@ snapshots:
 
   validate-npm-package-name@6.0.2: {}
 
+  validate-npm-package-name@7.0.2: {}
+
   vanilla-colorful@0.7.2: {}
 
   vary@1.1.2: {}
@@ -18411,12 +17531,12 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1):
+  vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2):
     dependencies:
-      esbuild: 0.25.10
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
+      esbuild: 0.25.4
+      fdir: 6.5.0(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.8
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -18425,56 +17545,43 @@ snapshots:
       jiti: 2.6.1
       less: 4.2.2
       sass: 1.85.0
-      sugarss: 4.0.1(postcss@8.5.6)
+      sugarss: 4.0.1(postcss@8.5.8)
       terser: 5.39.0
-      yaml: 2.8.1
+      yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@14.18.63)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1):
+  vitest@4.1.0(@types/node@14.18.63)(@vitest/browser-playwright@4.1.0)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2)):
     dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
-      expect-type: 1.2.2
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.3
-      std-env: 3.10.0
+      std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1)
+      tinyrainbow: 3.1.0
+      vite: 6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 14.18.63
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(vitest@4.1.0)
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
-
-  void-elements@2.0.1:
-    optional: true
 
   w3c-keyname@2.2.8: {}
 
   wait-on@9.0.4(debug@4.4.3):
     dependencies:
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.6(debug@4.4.3)
       joi: 18.0.2
       lodash: 4.17.23
       minimist: 1.2.8
@@ -18505,44 +17612,46 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2):
+  webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.105.2)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.105.2)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.2)(webpack@5.105.2)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.105.4)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.105.4)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.2)(webpack@5.105.4)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
-      envinfo: 7.18.0
+      envinfo: 7.21.0
       fastest-levenshtein: 1.0.16
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
-      webpack-dev-server: 5.2.2(webpack-cli@5.1.4)(webpack@5.105.2)
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4)
 
-  webpack-dev-middleware@7.4.2(webpack@5.105.2):
+  webpack-dev-middleware@7.4.2(tslib@2.8.1)(webpack@5.105.4):
     dependencies:
       colorette: 2.0.20
-      memfs: 4.51.0
+      memfs: 4.56.11(tslib@2.8.1)
       mime-types: 2.1.35
       on-finished: 2.4.1
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
+    transitivePeerDependencies:
+      - tslib
 
-  webpack-dev-server@5.2.2(webpack-cli@5.1.4)(webpack@5.105.2):
+  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.23
-      '@types/express-serve-static-core': 4.19.7
+      '@types/express': 4.17.25
+      '@types/express-serve-static-core': 4.19.8
       '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.9
+      '@types/serve-static': 1.15.10
       '@types/sockjs': 0.3.36
       '@types/ws': 8.18.1
       ansi-html-community: 0.0.8
@@ -18551,27 +17660,28 @@ snapshots:
       colorette: 2.0.20
       compression: 1.8.1
       connect-history-api-fallback: 2.0.0
-      express: 4.21.2
+      express: 4.22.1
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.23)
-      ipaddr.js: 2.2.0
-      launch-editor: 2.11.1
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
+      ipaddr.js: 2.3.0
+      launch-editor: 2.13.1
       open: 10.1.0
       p-retry: 6.2.1
       schema-utils: 4.3.3
       selfsigned: 2.4.1
-      serve-index: 1.9.1
+      serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.2(webpack@5.105.2)
-      ws: 8.18.3
+      webpack-dev-middleware: 7.4.2(tslib@2.8.1)(webpack@5.105.4)
+      ws: 8.19.0
     optionalDependencies:
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
+      - tslib
       - utf-8-validate
 
   webpack-merge@5.10.0:
@@ -18591,14 +17701,14 @@ snapshots:
       source-list-map: 2.0.1
       source-map: 0.6.1
 
-  webpack-sources@3.3.3: {}
+  webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.2):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.4):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4)
 
-  webpack@5.105.2(esbuild@0.25.4)(webpack-cli@5.1.4):
+  webpack@5.105.4(esbuild@0.25.4)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -18606,11 +17716,11 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.1
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
+      enhanced-resolve: 5.20.0
       es-module-lexer: 2.0.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -18622,11 +17732,11 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.4)(webpack@5.105.2)
+      terser-webpack-plugin: 5.4.0(esbuild@0.25.4)(webpack@5.105.4)
       watchpack: 2.5.1
-      webpack-sources: 3.3.3
+      webpack-sources: 3.3.4
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -18646,7 +17756,11 @@ snapshots:
 
   which@5.0.0:
     dependencies:
-      isexe: 3.1.1
+      isexe: 3.1.5
+
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -18675,19 +17789,19 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 7.2.0
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 
   ws@8.17.1: {}
 
-  ws@8.18.3: {}
+  ws@8.19.0: {}
 
   xmlhttprequest-ssl@2.0.0: {}
 
@@ -18701,10 +17815,7 @@ snapshots:
 
   yaml@1.10.2: {}
 
-  yaml@2.8.1: {}
-
-  yargs-parser@20.2.9:
-    optional: true
+  yaml@2.8.2: {}
 
   yargs-parser@21.1.1: {}
 
@@ -18714,17 +17825,6 @@ snapshots:
       decamelize: 4.0.0
       flat: 5.0.2
       is-plain-obj: 2.1.0
-
-  yargs@16.2.0:
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
-    optional: true
 
   yargs@17.7.2:
     dependencies:
@@ -18745,7 +17845,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  yocto-queue@1.2.1: {}
+  yocto-queue@1.2.2: {}
 
   yoctocolors-cjs@2.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,13 +57,13 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: ^2.2.3
-        version: 2.2.3(@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1))(@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.6)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1))
+        version: 2.3.1(@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2))(@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.8)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2))
       '@analogjs/vitest-angular':
         specifier: ^2.2.3
-        version: 2.2.3(5622f3d6cbc74853aeb2325ebf0c618b)
+        version: 2.3.1(d014764e7ce56e7bffbd51c6d32db63d)
       '@angular-devkit/build-angular':
         specifier: ^19.2.19
-        version: 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1)
+        version: 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2)
       '@angular/cli':
         specifier: ^19.2.20
         version: 19.2.22(@types/node@14.18.63)(chokidar@4.0.3)
@@ -174,7 +174,7 @@ importers:
         version: 4.1.0(@types/node@14.18.63)(@vitest/browser-playwright@4.1.0)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
       webpack:
         specifier: ^5.94.0
-        version: 5.105.2(webpack-cli@5.1.4)
+        version: 5.105.4(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
@@ -191,11 +191,11 @@ importers:
         specifier: '>=19.2.19'
         version: 19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(@angular/platform-browser@19.2.20(@angular/animations@19.2.20(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(@angular/common@19.2.20(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1))(rxjs@6.6.7))(@angular/core@19.2.20(rxjs@6.6.7)(zone.js@0.15.1)))(rxjs@6.6.7)
       '@ckeditor/ckeditor5-integrations-common':
-        specifier: ^2.2.2
-        version: 2.2.3(ckeditor5@47.6.0)
+        specifier: ^2.2.4
+        version: 2.2.4(ckeditor5@47.6.1)
       ckeditor5:
         specifier: '>=47.0.0 || ^0.0.0-nightly || ^0.0.0-internal'
-        version: 47.6.0
+        version: 47.6.1
       rxjs:
         specifier: '>=6.0.0'
         version: 6.6.7
@@ -228,10 +228,6 @@ packages:
     peerDependenciesMeta:
       zone.js:
         optional: true
-
-  '@angular-devkit/architect@0.1902.20':
-    resolution: {integrity: sha512-tEM8PX9RTIvgEPJH/9nDaGlhbjZf9BBFS2FXKuOwKB+NFvfZuuDpPH7CzJKyyvkQLPtoNh2Y9C92m2f+RXsBmQ==}
-    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
   '@angular-devkit/architect@0.1902.22':
     resolution: {integrity: sha512-98NCVZZwDoL1oW0aj9Wd7piIkt/oSjMZEI04f3oL5nGD1LoXcN7BrYKXIpZ4NP4Pfn+7gJo3nrhglHnhcwQXyg==}
@@ -288,15 +284,6 @@ packages:
       webpack: ^5.30.0
       webpack-dev-server: ^5.0.2
 
-  '@angular-devkit/core@19.2.20':
-    resolution: {integrity: sha512-4AAmHlv+H1/2Nmsp6QsX8YQxjC/v5QAzc+76He7K/x3iIuLCntQE2BYxonSZMiQ3M8gc/yxTfyZoPYjSDDvWMA==}
-    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
-    peerDependencies:
-      chokidar: ^4.0.0
-    peerDependenciesMeta:
-      chokidar:
-        optional: true
-
   '@angular-devkit/core@19.2.22':
     resolution: {integrity: sha512-OqN/Ded+ZKypPZN5+qUFwtnKGl7FKpxJXYO2Vts5vLBojY5goCZd9SGW1CyXeuPnisRUW+vjqBQbWYuEUh36Tw==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -306,8 +293,8 @@ packages:
       chokidar:
         optional: true
 
-  '@angular-devkit/schematics@19.2.20':
-    resolution: {integrity: sha512-o2eexF1fLZU93V3utiQLNgyNaGvFhDqpITNQcI1qzv2ZkvFHg9WZjFtZKtm805JAE/DND8oAJ1p+BoxU++Qg8g==}
+  '@angular-devkit/schematics@19.2.22':
+    resolution: {integrity: sha512-tvfu5jhem1o8qidVxvXe5KfCij65ioMLCOFA947DD+zb3yTl5pJyDm2dqzbOehuQw0fmH4XPQukRJsCUy+UwaA==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
   '@angular/animations@19.2.20':
@@ -1101,59 +1088,59 @@ packages:
       '@ckeditor/ckeditor5-utils': '>= 37.0 || ^0.0.0-nightly || ^0.0.0-internal'
       ckeditor5: '>= 37.0.0 || ^0.0.0-nightly || ^0.0.0-internal'
 
-  '@ckeditor/ckeditor5-adapter-ckfinder@47.6.0':
-    resolution: {integrity: sha512-SMGuLMvXlNK9NjKL24zjV1JK3KCQxMoafTFEW5iGiKA63g9GNmhVhpu56dT+9bRpOzDNchnSYW9ljuW04bDr4g==}
+  '@ckeditor/ckeditor5-adapter-ckfinder@47.6.1':
+    resolution: {integrity: sha512-X4l4KyLgSsmAyRd/YY8R/OArOXR2Ts8NyoW6k+tLtYxEmZOhJsa6ZFSho/OVTole7IqMl+Zo93b9YaAwX23brw==}
+
+  '@ckeditor/ckeditor5-ai@47.6.1':
+    resolution: {integrity: sha512-raNc9uiLEGZCjF9HWQTGu2HRfPDezZHC5KURFEgYrVyc0KL61bhGi1hXw0rpn0qNUF42yuDuUwtwK+Vo3wgq0w==}
 
   '@ckeditor/ckeditor5-alignment@47.6.1':
     resolution: {integrity: sha512-2u1+Eseelrm5gKKajE9X+gcPchVAIna3AkoJyCw3+Y4dBc6ElWZJEuCO7b6Omv5H7q3lQimbaqJnvIE1Z/nXOA==}
 
-  '@ckeditor/ckeditor5-alignment@47.6.0':
-    resolution: {integrity: sha512-vfu+Hsza8kW0ehf+7N1hibmWRQpJ84CTPWjM9PNtwb+irvnQ3WjAK8D0fw9dY+ZM7FtPCT9xJGCDCI5MoRZ/fA==}
+  '@ckeditor/ckeditor5-autoformat@47.6.1':
+    resolution: {integrity: sha512-UI3HFyw7VCTM92IhE6hdIh5rp2nqOLL4vnnOFTgp7Lq6dLOVzuwsRJLIEfYxz4Xusy4UKu4zM8QX4FV1nOWsGQ==}
 
-  '@ckeditor/ckeditor5-autoformat@47.6.0':
-    resolution: {integrity: sha512-idBf0RsdKr1sIcaupIqHksx6VPzGtCsKi4ZjAfFl4syVCvx3lPpJselkkvsdpTmw0Rqg4x8zyfMGElSL82SXuA==}
+  '@ckeditor/ckeditor5-autosave@47.6.1':
+    resolution: {integrity: sha512-7om5OHf2hBDi/Md8lVZL6fF7gCBAMVZfg8zsJqTmAW6fwl5gfenD4rggPdSa4GVt+mZXbheZx9EWc0HX1psAew==}
 
-  '@ckeditor/ckeditor5-autosave@47.6.0':
-    resolution: {integrity: sha512-bU7E14bu/8paefBMtOT61P5V95fdafaG3OQXdnE5tHD7jrualznuEzek519U5VzL8Gh1Wo4cHyLA2pg1Ljyb/A==}
+  '@ckeditor/ckeditor5-basic-styles@47.6.1':
+    resolution: {integrity: sha512-/8R59UxR/8quK8UmOLOS1xq47GnB+oMNySo8BgLHJl7qepRR5VnWU0hHB239idnFk46IVhuRciXQHjifrJiScQ==}
 
-  '@ckeditor/ckeditor5-basic-styles@47.6.0':
-    resolution: {integrity: sha512-GYYO//eNp13ZGn7Fg7s9eSdaDLt/Hut6efC8gTkakfx2yCZqcjzjV4gBJmvaIul1hw+EzsMjBhYe4lorBAM5oA==}
+  '@ckeditor/ckeditor5-block-quote@47.6.1':
+    resolution: {integrity: sha512-wyDLqGrmcDVNlRmHxXTpXg2PKImgB4yIU3UDRofFKVJiuvnZvKKvx/Oh9USVv1G1zOAPoFyoK9AQzqYNOB7AMQ==}
 
-  '@ckeditor/ckeditor5-block-quote@47.6.0':
-    resolution: {integrity: sha512-xFydZ2+1tcv5TcqoWPtlDJ0wntujOJfIrXncqDe6wXXe/ByK5/wJu2d88XxLQFCNvn3BjP9VLBQNrKIAlpFM1A==}
+  '@ckeditor/ckeditor5-bookmark@47.6.1':
+    resolution: {integrity: sha512-9HwVudGBEhbqMPkEXQTqSIACGYpOWlES7bOxdG6WfgOUOAdCiTPXFCc5f+HSMFbrwd7XJ40tycPLOa7XK14oEg==}
 
-  '@ckeditor/ckeditor5-bookmark@47.6.0':
-    resolution: {integrity: sha512-Bkxh46mHCEYM9cOSJjK6NpHtBpSyJWqYVyTrLl24SiixtHUpuXqFKKM7Jo23GjcuPBXVSdG2ax6iwUCzcFuHAg==}
+  '@ckeditor/ckeditor5-case-change@47.6.1':
+    resolution: {integrity: sha512-B/6OczzVBsFgyQW0SjK2HylVe6SjDfShwJdcL3QRxFv6FefzkB5UbU4nChGTzLm7Xy6cOP7CyVsBKCDqFmirfQ==}
+
+  '@ckeditor/ckeditor5-ckbox@47.6.1':
+    resolution: {integrity: sha512-v083Tnbsx4z1fFW+ghMXlsf5EgB3UaSldjfRsipjIYUiUeatccgRN00Qh6qGMlYz7zZcSdUUtrOfTWL/LYPWDg==}
+
+  '@ckeditor/ckeditor5-ckfinder@47.6.1':
+    resolution: {integrity: sha512-ewgqgtQaDDZHQUGby/gg2/840Go280bvx959ExQH8Y7u4fPVw8NEFYAxjcm43W6EXgMnlmsEr8+G8q8g4iKT1w==}
+
+  '@ckeditor/ckeditor5-clipboard@47.6.1':
+    resolution: {integrity: sha512-F3KQuCnnCavm8wXvX+d1KN/obh5ux/jT9qC/71QfMKdDvHxEOzi/t3YWa1r3sztlksDQ4LtODU4uWh0vVKUpkg==}
+
+  '@ckeditor/ckeditor5-cloud-services@47.6.1':
+    resolution: {integrity: sha512-yC9aqornbxjgNhHuUX4gcuvPTLv34sc8CbUOeFYLGbD9ujwoC0fzzjzSB7u5b8fWNg6cAjzriFooJATHBvu40g==}
+
+  '@ckeditor/ckeditor5-code-block@47.6.1':
+    resolution: {integrity: sha512-ntZBIEYLoC4/OTUgCkwwmyXwwqDk8QwFcx/1kZN7S4YtwocREZqpDH1wYT+GA2ZmGkjaBRxdTLwSVr/7bf+wqg==}
+
+  '@ckeditor/ckeditor5-collaboration-core@47.6.1':
+    resolution: {integrity: sha512-TcUyOC+CpH45nbiw684tUNiBMZStKTkjRexG4YBVCMXE/W26nFf/4ISONycPNLCZolFWwFvtPfGsrOLPg7208Q==}
 
   '@ckeditor/ckeditor5-comments@47.6.1':
     resolution: {integrity: sha512-cLTMoTsrMiN7jRhU2sl/JPy/YmHckis5P8kxpiXeYNzSXzY9y1tGaNgFsr1j1VIZFm9FTmKRRKqVmx7twALSKA==}
 
-  '@ckeditor/ckeditor5-ckbox@47.6.0':
-    resolution: {integrity: sha512-IOpJZMc8NLe4ruLfG8jfwC84yEbTqn/0rUyKgdmTf6M5ZofpIMyaqSIU30aULBgmaXwkE/hQTbfjgaJ3UUSo5g==}
+  '@ckeditor/ckeditor5-core@47.6.1':
+    resolution: {integrity: sha512-6dtnquhjymLkNhdC9T6gk/Mf2bDnHSTZrhkByaXC96CbmQDriCgfcaAVY6pQgDNxBQ6fZrev0TnKBLfTItrMsg==}
 
-  '@ckeditor/ckeditor5-ckfinder@47.6.0':
-    resolution: {integrity: sha512-hCuFkKx/ph5ntmCSvjO7zIxET/pL/5Q1fYt1joOE9hjaBWFMoRao87GUjJ3O751ZAkioSe90zECP8SXYz8ZlIQ==}
-
-  '@ckeditor/ckeditor5-clipboard@47.6.0':
-    resolution: {integrity: sha512-ymkOH+O9C+v3vKTaw1iOrlJMti+7Q9ycKdP5bCc9/4ywtR6cRtZ5BnEkbK1S1CSxkijQCdpe+0tNgXI2aniD+A==}
-
-  '@ckeditor/ckeditor5-cloud-services@47.6.0':
-    resolution: {integrity: sha512-8MkrqbfiglNwqkUnfL0uoBZVlHmsqvq6wXiz60fnWTpTiEmxzV95/JeT7toFafvxLO7WSzBjEcZcmc9Z6ChyAw==}
-
-  '@ckeditor/ckeditor5-code-block@47.6.0':
-    resolution: {integrity: sha512-SetV7GnNwUOqyaPHlzXgTuT/TrLLhQ9z3glmfIQ4A9BvV9dvP6Nb9vFeJnDHuhEwBauQS8M0DqdFc+F3qdJwsg==}
-
-  '@ckeditor/ckeditor5-collaboration-core@47.6.0':
-    resolution: {integrity: sha512-Xbz/S+uiHZv9SHlahR2Cv6Tjofz4XOZDlSOuAZyVkjhdjiAbIUPUATxERH4KJyiUkr14HkOAWY37ZZ1S1dYX6g==}
-
-  '@ckeditor/ckeditor5-comments@47.6.0':
-    resolution: {integrity: sha512-Mzx0CM+kODEjkla6w1qaiSPFNebSn7XKuPpXlParnb6H8kiDLuTPA/l4kEEuByKEKuqUYFmV7S62nj9N29kQVg==}
-
-  '@ckeditor/ckeditor5-core@47.6.0':
-    resolution: {integrity: sha512-kw1zN6Fv5SRiZBSCfJV8yBGmirNC+vnKBOKxiS5I50wRReH90IJnTyh5Fu/vqsmr7UtSR5xvAKhu4xg30MrsRQ==}
-
-  '@ckeditor/ckeditor5-dev-bump-year@54.3.4':
-    resolution: {integrity: sha512-Xben24lWt/weGc3N6iEUBonyFJFEaCbmJ0P+/fggwaxPy8O4zHAE3uW60ErYmtN8ZSA3OEUz/qNHoR7acfS3zQ==}
+  '@ckeditor/ckeditor5-dev-bump-year@54.5.0':
+    resolution: {integrity: sha512-V1le+yC1n6tG7//oWoKQRUtxHx2Hnl9XHb5sNRvt8365mQGpghG8JyTrgSdcJFTqUQB/pQRpqHTnZKuTgxFD3Q==}
     engines: {node: '>=24.11.0', npm: '>=5.7.1'}
 
   '@ckeditor/ckeditor5-dev-changelog@54.5.0':
@@ -1181,38 +1168,68 @@ packages:
   '@ckeditor/ckeditor5-document-outline@47.6.1':
     resolution: {integrity: sha512-zK6MtLfpyxv9VIKrFj5zB5uF1pk2zkGViS3SpPn6UE0opINfbrV2WqKlfbbwzSKgruzTrsH+fbFnKslgHtRI1w==}
 
-  '@ckeditor/ckeditor5-easy-image@47.6.0':
-    resolution: {integrity: sha512-hOTxDnCU+d3vp0eKeULQxk3rZRkkZ551OM9O1ZE9sEaOjAdndaikqSH9VEwhSKTfmRIWHrMJg1ouxw2aeHvwHw==}
+  '@ckeditor/ckeditor5-easy-image@47.6.1':
+    resolution: {integrity: sha512-hWaqibO1ZUHRIkvvAO7O0qDAIw+GN6UWbdr0wcGNLc4DcSZMUIpAfoXuiyyvE9hQEJPpfTOwA3r0znS6wXtMCg==}
 
-  '@ckeditor/ckeditor5-editor-balloon@47.6.0':
-    resolution: {integrity: sha512-LsnDsovjVrif7mRbdwFJKmKI5q5xmD2Zi/8+ImsCUm6fOo9Q3nmairDoWhQ0Bm1KH1MFDFYCDzZXuiI42T2F8g==}
+  '@ckeditor/ckeditor5-editor-balloon@47.6.1':
+    resolution: {integrity: sha512-geszCykoE9Sja2tBqyMww4etAzAExg4eGnlYbXSGiaUiC7Ks4OqRVeuvw37QsH8Q56J5FQC35ysq95nrLEB+0A==}
 
-  '@ckeditor/ckeditor5-editor-classic@47.6.0':
-    resolution: {integrity: sha512-NF+YBnfacILu3+EvsEb5UZvE9llpcO0qfbDdxJUu+t8bHXMhZzo3kOh0Gw3mB3Yil62IVTita0P3AZvzq053zw==}
+  '@ckeditor/ckeditor5-editor-classic@47.6.1':
+    resolution: {integrity: sha512-w2QaF2ieqLqu6i9YldOpPnFezvAsXY/R/vp/c0D1ofvI1CtBRWhQ9/rRwADMoKgpcuyP2320sRG312anT8aiaA==}
 
-  '@ckeditor/ckeditor5-editor-decoupled@47.6.0':
-    resolution: {integrity: sha512-BgwJZUJEzR06bLf1Qk6Klilaacumk4uMZCAdQCCg4LSMNAk3eaQgccl6SUZqUH9V/NDpogIGcaDbUPWvuxJKjQ==}
+  '@ckeditor/ckeditor5-editor-decoupled@47.6.1':
+    resolution: {integrity: sha512-w047UpjHF106k0NeQLgWY03k29s5vIpS9M6Oj+f+IdKaf4TR7uSzl/CXsS+csfqwZEhtGwGV3LYJVzo35+SifA==}
 
-  '@ckeditor/ckeditor5-editor-inline@47.6.0':
-    resolution: {integrity: sha512-89B+SYsuI64mfu/qtIyYarw0qSmripIA33L3FaH6KUJpPBwwIjd5huZg6L5BXE6ZuPMGyRjRq6JapQb0zExWEQ==}
+  '@ckeditor/ckeditor5-editor-inline@47.6.1':
+    resolution: {integrity: sha512-UJQHbMh1nvsHMuiijmRx3y/5ssdxeJTrVjrwDoPlUsI8tfRYjkdIucd9SsRhXnV65Vk31Ah5wiFyaBb5OLXZaA==}
 
-  '@ckeditor/ckeditor5-editor-multi-root@47.6.0':
-    resolution: {integrity: sha512-uA5JPlV7QFfMVErqoVdwLJbUoF/u3X3GGg5s+VMeVoVTnn3ZQ8592HVftuT87HIiI8W1NHdlrE/32+3iTnOoVA==}
+  '@ckeditor/ckeditor5-editor-multi-root@47.6.1':
+    resolution: {integrity: sha512-Jn55iVT2sg85NSPVe/mThLoiI0FTAEH5r48MXD1MKz1E5K0FkpdLiKyCR4onfdFLozWZW2NvU0faCkyI0BKaZQ==}
+
+  '@ckeditor/ckeditor5-email@47.6.1':
+    resolution: {integrity: sha512-OqYd63dJJuu9KCUrb17geeiw1gcWkpYQyCcoiJEoyCZLXAPmGmECeCrdTvoI7f7d0/BttBWaSN9Y6rrN2fwMWQ==}
+
+  '@ckeditor/ckeditor5-emoji@47.6.1':
+    resolution: {integrity: sha512-bnnnvRk/eYrvKLLQpJrjSV++Abpm1/8N31BNVaZyeHzaI0pddE6ikS44Ju82u7BQJaqSi2SO2Glx3u3C14rm2g==}
+
+  '@ckeditor/ckeditor5-engine@47.6.1':
+    resolution: {integrity: sha512-Xb398PRhkJqtUuQ1E1pdLXTG1REIOanr7PCIRPpWvpHAIZZAuxTIqyacZC4qVTS9xI+ObxYqosf8yNvFsEtu8w==}
+
+  '@ckeditor/ckeditor5-enter@47.6.1':
+    resolution: {integrity: sha512-H/d5L8JmZFmb5wYDi3NT4NICYuRueGUwiPgIpaaQ0gb8U3U0YVj4J5WVF/65KGiYdsuP2NupSwRqsdl8TilrdQ==}
+
+  '@ckeditor/ckeditor5-essentials@47.6.1':
+    resolution: {integrity: sha512-4A9E9GrOudYA/eWCXE9uLqEdw7RLO/OdmeY1KWGAF6B9fubieSCF+S69M3c5hMKS6KJoNjaVJ/iR91KfIyYmtw==}
+
+  '@ckeditor/ckeditor5-export-inline-styles@47.6.1':
+    resolution: {integrity: sha512-ryy4gcWqeSMHLEw9q/caqlTBOFMqUSSRtdPKw5n7P2+AReVz2bX0gMJFk913jrSLWh1v5ErqAqlB37PfCZLLUQ==}
 
   '@ckeditor/ckeditor5-export-pdf@47.6.1':
     resolution: {integrity: sha512-Q7/uAKSCwen33mBAiTg5/dhnfmcr1BWZxX0PpbRAjlO5NrFXCd7EuQuoWZQEoC5d1N13yEBk5YqueoaFxHUTXw==}
 
-  '@ckeditor/ckeditor5-emoji@47.6.0':
-    resolution: {integrity: sha512-DLoScPQAMKXpe6U3M6Dw2sed0ElQeMgun0B/j//EfBPdtqkY3IDPg/R7SlRxsYuYNf0cEWNZwaNnlL/JI6w+gA==}
+  '@ckeditor/ckeditor5-export-word@47.6.1':
+    resolution: {integrity: sha512-RQPtKANSeUxMbGHuG7skX88b6CQ919ToC+yUkP3ZHn/lvvNpcR6CWDHN0PwRHIGJNVc1ifCapZAOXMO7Jg3yhA==}
 
-  '@ckeditor/ckeditor5-engine@47.6.0':
-    resolution: {integrity: sha512-HjtlviZZhPDSfHS7aEYUfhVuEWCHCyjCUDd4r4vx9A+02W7G+Gg6I0lqtDqTRL/Bp5rVv3MeRrcaYU21jCFJ3Q==}
+  '@ckeditor/ckeditor5-find-and-replace@47.6.1':
+    resolution: {integrity: sha512-ZbKlNpFYCP0DRICJlhyTLaRlPSwdJ5W9BBrMFjHhGsKNbFJ2KHlPCqTD6nAEWc838heDBZM21jRGTM6O92FLHA==}
 
-  '@ckeditor/ckeditor5-enter@47.6.0':
-    resolution: {integrity: sha512-+WlxCGj4J+Q+BFyAWkJZ6q+t4LnDHEstQtYFT5pGj23oUSVeOBzc+7e5FqU4LLtOzYnClN7t98OGPDPOHHhS9w==}
+  '@ckeditor/ckeditor5-font@47.6.1':
+    resolution: {integrity: sha512-ayMtG44tLbmPBjoEudnF7kFkqX3GUO0Cb1lLd6JR5B4uyoNFuQbN3nyrtx7hMvdu0N4jl0hWcWXjdu6vNL4I6g==}
 
-  '@ckeditor/ckeditor5-essentials@47.6.0':
-    resolution: {integrity: sha512-rI5/FWOcMjGVtWlHisBQCtL88pCZJiB+SwpmpumdALqP99urUqbL8tFprwyv95r7o4sFPMymJYVdHGlUjKb4Dw==}
+  '@ckeditor/ckeditor5-footnotes@47.6.1':
+    resolution: {integrity: sha512-dig0MLBWUiFKk/OhElD0A2HOvjLwCvZlZH4r0CXFiRAuC04LGsmVOsOnpb3M/qnIxpPt0EQMNJn7PxXd+DVRdg==}
+
+  '@ckeditor/ckeditor5-format-painter@47.6.1':
+    resolution: {integrity: sha512-G8w4HWbweMESBBBsKC3HXLwhJ04gvksqOq1PTXpCe1p0uI6/baBUZs74A8mrgm2zHrHwFM+tB99qoIfBoyA4Ow==}
+
+  '@ckeditor/ckeditor5-fullscreen@47.6.1':
+    resolution: {integrity: sha512-LvA7vzeAkuc/z64kuRu17zm7EIFe0Bqt9xPA5GhfR6T9mBVG4wu62ElqylFUjFJ+macvkjSe68tBYQTAPyUWqg==}
+
+  '@ckeditor/ckeditor5-heading@47.6.1':
+    resolution: {integrity: sha512-4kVuMaaAylkxYkJ0PA4hUQCDTARoeokkqKh0dE3DwEZTvvWDZjBEAhIKaSVX116ByeGfImbLkBRAoNCljKNCHQ==}
+
+  '@ckeditor/ckeditor5-highlight@47.6.1':
+    resolution: {integrity: sha512-hEIAZAImLAGRsz7/d+bbh3k+9s854AxuYoTmCAN2u07muYX/pmrLrLm6cZcazjmi9J/Bow6sP/D5GeoYMWKkLA==}
 
   '@ckeditor/ckeditor5-horizontal-line@47.6.1':
     resolution: {integrity: sha512-YTSpxdrp8NteaWARH89dA+qUWAf3agw/Q1dRQF+XdiF2kaSXRPQCXJruvmy490H+3xtwUZVs/hSlwX9gT77Skg==}
@@ -1223,119 +1240,130 @@ packages:
   '@ckeditor/ckeditor5-html-support@47.6.1':
     resolution: {integrity: sha512-F25LY88VYx0gZTrrThmt+kqF2thrwg52ZCIQeRujMd3RIueYEAEn7ZJ0p5iArDvm9qQXtLzsaijEyZr2edstPA==}
 
-  '@ckeditor/ckeditor5-find-and-replace@47.6.0':
-    resolution: {integrity: sha512-S6E6zgO3T4A5rFC3Idr7DvhD2QEov2yIrWVbkIFTc0Q4fuvuNIxoke59fvc+SYd9BeDvQawP7a3RjMBTgvVRGA==}
+  '@ckeditor/ckeditor5-icons@47.6.1':
+    resolution: {integrity: sha512-OEk5hPdMpE5/Cb2lZFtJL2XyMwy/S8xQzuAk2b2P2bJx33rJgU3pk9RUrayxCSa3p+tKqibOzm5GcshLJ7s7Tg==}
 
-  '@ckeditor/ckeditor5-font@47.6.0':
-    resolution: {integrity: sha512-MZ9nUVCF+H+uYZeEy2FRlRys4kUFhuFcTJSaVNh6+obC8p9yrdRk9sSIKzH3VfJwmY9RWwEGg5udcyuQ4QT7KQ==}
+  '@ckeditor/ckeditor5-image@47.6.1':
+    resolution: {integrity: sha512-yy7b/7WQqN0c7/VC1Ng5svQU1btXWauBfQjFgVV3AzGa+nVeJ1ZIcV2fAkUa6mB+lCu+5ziv7b7ord22baJYzg==}
 
-  '@ckeditor/ckeditor5-footnotes@47.6.0':
-    resolution: {integrity: sha512-XzxR/KJJ1cO1mH24eJ96e4xVRZFxE/qJHfWH1v5cyHlhgf3TJfztqN2leZBR6BWyBGj+rQH8VYBvmJu0zzytTw==}
+  '@ckeditor/ckeditor5-import-word@47.6.1':
+    resolution: {integrity: sha512-RETw654yL9JxdE1pdhXLPL7b3UbNxO3B16rBPRM2gcfdUOnRUv6OzgsTICMedRWmRRmqhTqdgdQyVD7ReryyHg==}
 
-  '@ckeditor/ckeditor5-format-painter@47.6.0':
-    resolution: {integrity: sha512-/ycXinrkmbjiRPzXSQ946MF9GQIUCv42QvvOAS6jiuLQMXbPCLC7seniF54AQoZylNLfcpwO72GTz2pNCfjmjw==}
+  '@ckeditor/ckeditor5-indent@47.6.1':
+    resolution: {integrity: sha512-SaokgxUJevRrYfu5PKEMvVrUliybmxpb3Cx/f/JtOnPbyJSFrt05+/mt3XsqsSB0g8LaHH2PXQfD4vncGzE6DQ==}
 
-  '@ckeditor/ckeditor5-fullscreen@47.6.0':
-    resolution: {integrity: sha512-M53UtSJ5jLNwt34iqllHeW2zT7HEpZwzSWX/TLn/3Q4d95m9+HAO4vBHDkuX+wd2KTl+8MYcrXYSCNWDqWzU/A==}
-
-  '@ckeditor/ckeditor5-heading@47.6.0':
-    resolution: {integrity: sha512-hduHYHzcY3j+K4e2O6A72ksH16I885zWjydwFOCGXnIPUTZAL9ZZLwRuhqDQ6jZ8uNPqiXcuRpZd1tFIXbKXOg==}
-
-  '@ckeditor/ckeditor5-highlight@47.6.0':
-    resolution: {integrity: sha512-YXZWN6nIyVBrVvsYXkusruYYenNb84g6GgWilA2PwQxuW6CwTJ7PeAM9KkA3+HQm/hwAme+/I74940FoyOXMnA==}
-
-  '@ckeditor/ckeditor5-horizontal-line@47.6.0':
-    resolution: {integrity: sha512-m7LZ0wS5GHfmm1rWR1xSs5a8e/CTx79k7ahZdexLmyKmVoI8d/rahsD7oPsaFz6E+lHHhFtz+mmcOURlpI8SCQ==}
-
-  '@ckeditor/ckeditor5-html-embed@47.6.0':
-    resolution: {integrity: sha512-i8/7VoWcPLuJGkGbDJVQMd63SdTVERDMcah9EqbDFR6uxX+BnhUdPDKiZmcrsIJ93uq6aiK8p3uDmoiEomWp6w==}
-
-  '@ckeditor/ckeditor5-html-support@47.6.0':
-    resolution: {integrity: sha512-bGIhD71IUYfdC87LVh3kLDlB6UuMSyBAOPpEsOr/7r8oANhHgUI10BaImZVid03e5Wn5x+S9Jc9v1T38+eRzAQ==}
-
-  '@ckeditor/ckeditor5-icons@47.6.0':
-    resolution: {integrity: sha512-Flu9jiUG7BjVfSdIXnCx4IBshDh4G/Aw6JhnysKstA4RvAOypF7hVkuYw2tqNUdkG7YV9LbYlTlWitFvWEazkw==}
-
-  '@ckeditor/ckeditor5-image@47.6.0':
-    resolution: {integrity: sha512-7X5qtCvqTSc3hJcxe6qTZ2WVIW0Q81z4l4ehIpiNF/vg4FogsSXPyJ5xro2KrNILLIXJzMx20a7BFN2S2HcepQ==}
-
-  '@ckeditor/ckeditor5-import-word@47.6.0':
-    resolution: {integrity: sha512-IVewuKEjQfWX5wfl/eHKiVT7AnpyFGdkE6gGzZoDR7zjKV31s2XMNgbgMMv+H5p7CXejRNceze4Phx5tGiDk/Q==}
-
-  '@ckeditor/ckeditor5-indent@47.6.0':
-    resolution: {integrity: sha512-Rsnw5FHUGRlzyixRtgLeCrK2u3+d1+Bliq8hlQcMWvXB7wfD1GTDSsEU2MxGM7QtGuMbqFa+gO0hfzjEFgRv5g==}
-
-  '@ckeditor/ckeditor5-integrations-common@2.2.3':
-    resolution: {integrity: sha512-92kQWQj1wiABF7bY1+J79Ze+WHr7pwVBufn1eeJLWcTXbPQq4sAolfKv8Y8Ka9g69mdyE9+GPWmGFYDeQJVPDg==}
-    engines: {node: '>=18.0.0'}
+  '@ckeditor/ckeditor5-integrations-common@2.2.4':
+    resolution: {integrity: sha512-Qd6nTE6ldCZ8JyCVZWBRmBOqQnV/LlGHZqsnhxYv5IbXkJuUdskbsg+0VYDD1v9JEH2B0sTHLY3WYJHpijm2tg==}
     peerDependencies:
       ckeditor5: '>=42.0.0 || ^0.0.0-nightly'
 
-  '@ckeditor/ckeditor5-language@47.6.0':
-    resolution: {integrity: sha512-nwV0HvQ7xhADG74TdsYZaB3rgiJMlXEqZ1rUQ+Lcl/IcYWCeyL8UaW6CwHzwlod2wTwaZhoIgfEMAk0f50b+qg==}
+  '@ckeditor/ckeditor5-language@47.6.1':
+    resolution: {integrity: sha512-YZpySDIa4Y40T9wwKIFsAlDujELkgUtoKw/+4Wl8BHlDnq/40VxXFbOSSXu4TnnVeqVFcnzTjp6Zv8CHtmY3yw==}
+
+  '@ckeditor/ckeditor5-line-height@47.6.1':
+    resolution: {integrity: sha512-oGhvlISZxq2pIOUzXvNwxbpzZiJH7A5rI17twEyLSxGWFNXkKRrnqJJng3GocTGfprqMXAgUA+4GDxFQ+hfSWQ==}
 
   '@ckeditor/ckeditor5-link@47.6.1':
     resolution: {integrity: sha512-A/gjF7e00R/ESUotqR08EeGM91V031DiHiGwYn7b+iZ1bejsdEu3yQK707bZ4U6ByEYBUOMtq1bOMYUtGJl6EA==}
 
-  '@ckeditor/ckeditor5-link@47.6.0':
-    resolution: {integrity: sha512-YEw1y9nMqF3hYbrJ47DbeMGpyZj04uDf89tcYR5Ti27k3P4gqwCjBh/L/q+yiRmDXhfLbne7Zb4sqF6TVDBqog==}
+  '@ckeditor/ckeditor5-list-multi-level@47.6.1':
+    resolution: {integrity: sha512-vpf24tZf8Mdi/rUvsDqdLHkgLc6UiHqtp/Oe50yTjLM+hftewIyF6Vm18Qzc53MdtvNRWFwwZIVM4ZHorIT63Q==}
+
+  '@ckeditor/ckeditor5-list@47.6.1':
+    resolution: {integrity: sha512-k7lXRJpZ8vkMQy0EWoYD8U6rQqYuKEbrTshlIjZSuBOQ9qlAb9llJ80OO0gteYZBOCMde1BJGjCeVxSNAI6eFA==}
 
   '@ckeditor/ckeditor5-markdown-gfm@47.6.1':
     resolution: {integrity: sha512-bt4UsDKTmq5iyu5TkmxpC/Z5zZEsw8bcCr5egjgNtV5ozJF1E+54iQBjKIYNYIWRdD0PAEEGFE15QoWzSHBtxw==}
 
-  '@ckeditor/ckeditor5-list@47.6.0':
-    resolution: {integrity: sha512-LyvFrLKZS3DjNX/9J+uRJ/AvwesqD1/+BfeqGF3eP0XWhqJLI4rePosyOl3H91050zWlDuLFINo4lYGL0xDkAw==}
+  '@ckeditor/ckeditor5-media-embed@47.6.1':
+    resolution: {integrity: sha512-G18SeOxXVy+k0SQYHkw1HQtS6/PkqpX2Mv6zM7os9aG3OpPmX8tCqDK+X7TaMx3FRJlDV0ujOy5Qfs71SJrqKA==}
 
-  '@ckeditor/ckeditor5-markdown-gfm@47.6.0':
-    resolution: {integrity: sha512-rgL51xVnVsXafj4OwyfjG4roZg6FXHMlcEsZsympauyehdl/IJeE9Jia8fuS7Joef7PJQNpadPr/5IE499e1Xg==}
+  '@ckeditor/ckeditor5-mention@47.6.1':
+    resolution: {integrity: sha512-/53LFzYqcgvd8pL02XlNBduucfnakDVvY86vC02spDuTsUH5qUMqLaz2FHSo9AH2y3kNVp98KDnqI/QjNZCd+Q==}
 
-  '@ckeditor/ckeditor5-media-embed@47.6.0':
-    resolution: {integrity: sha512-vKlNWEo8ICUzZXzpdo0ZA/rF6nzBglYI7EHRu1LSUAPeSA+gNoh8itXHRlox0wYQ1N5DT5f6Z6ZwxlK1pHQBQg==}
+  '@ckeditor/ckeditor5-merge-fields@47.6.1':
+    resolution: {integrity: sha512-vukSTLFSReqfEDPmJLjFsEJz5VKxTd3Wt8IHsazJ2ksmp9MUT2haN3hXkzdyVvJrrP1kRBSuiFfu+Vk8SrrG+w==}
 
-  '@ckeditor/ckeditor5-mention@47.6.0':
-    resolution: {integrity: sha512-odLiEzED4fTDn5SkM+RS5Rus32ghJp6+hcSWZIHwTTQ0QRJOGab+euKyY/PqNVP0rPI2Mq+Lz5uXRO5mfarahg==}
+  '@ckeditor/ckeditor5-minimap@47.6.1':
+    resolution: {integrity: sha512-ksKOy4wxzs3pkhfzVtnnsu5rgJxqYHMKM7X8Rkhx9BSshcKFeuNIUVsSh+7QWDQStWKSZ/qAx+0rezdJCm6gvQ==}
+
+  '@ckeditor/ckeditor5-operations-compressor@47.6.1':
+    resolution: {integrity: sha512-gnijLmjVP8VLiz97e5rGODgVqcpdXxUABs8eIBUtwyDAttQQ+f3rFxWxdT66fM6h+0cGNlLS7lJRBeJHG+NmQg==}
+
+  '@ckeditor/ckeditor5-page-break@47.6.1':
+    resolution: {integrity: sha512-KBE1tLsnyIsh0v+S6p0G+WglkvfWvKCkOESmap+gct5xwmOE0HEgRVp6xFFBfHYuGSjSISvgUU4ofdnhseZivA==}
+
+  '@ckeditor/ckeditor5-pagination@47.6.1':
+    resolution: {integrity: sha512-Dxx8BcPh4E/NH7mN5mzTlNGs0mkVqeKXGGHILTmwaO9vULr5s7r8TiXacRQZixp+pjb4FAGllvSvcHV0D/sE0A==}
+
+  '@ckeditor/ckeditor5-paragraph@47.6.1':
+    resolution: {integrity: sha512-6FXs94lSb6n7V7Puwp1c9BMyjycOfsAjdPRSVGTx1THqQBziQZHuZeU9LBxJZBA1mzoQOfmFaC3v+wb8odBgAQ==}
 
   '@ckeditor/ckeditor5-paste-from-office-enhanced@47.6.1':
     resolution: {integrity: sha512-k7DrfuyGjzTaS5N2drlhRZXGAkDZdjjF86OkyOy0EPS0y+FGNyrwf/O99WtD3ZG/2x+CxaN8sDygAhazNtyNFQ==}
 
-  '@ckeditor/ckeditor5-minimap@47.6.0':
-    resolution: {integrity: sha512-4hdS2HpkoYsx8cVsMFntN1nsvS0xsA8pHGiJFUMMNqooy77qDMRlAeaprRth+rQqruVNldGAdlnIs7LfqXoJug==}
+  '@ckeditor/ckeditor5-paste-from-office@47.6.1':
+    resolution: {integrity: sha512-Lt/V8/q59WuPURpwS9Z1UWUU1q5fF7YUbDAapWatzJlK9J/c969nRMG2aXm3z+BjXv3Kdu9qs4Oqngw0sJ0KiA==}
+
+  '@ckeditor/ckeditor5-real-time-collaboration@47.6.1':
+    resolution: {integrity: sha512-7UUbrUy3WeejQRMT7GKpHcHxz5nqiKhrjplQAIlp3wux9m20rWx7tCyLlGFu3nSFGSv2YclKx6rPH7qS/PUJtw==}
 
   '@ckeditor/ckeditor5-remove-format@47.6.1':
     resolution: {integrity: sha512-2lQvT4+OVIFQs67yKh54exnT5UV1rPjEZX7MqyhZ3Dr0rzyEW7b9tpFz7bP/EUOSa2LpFktNoLFOSnIAZnQdyQ==}
 
-  '@ckeditor/ckeditor5-page-break@47.6.0':
-    resolution: {integrity: sha512-XpWPVmbCtBJD1kOtBqV/LjsVByt94xlhgk9IXXW8QE/XOoNh5Yb2JE3MisHSZ0yM3kXauROM0SWT1FVMYXx2RQ==}
+  '@ckeditor/ckeditor5-restricted-editing@47.6.1':
+    resolution: {integrity: sha512-ufWtexBPqBxJNNjjIw9XQe8Q+cnwLV4en6PTvdBX/zXHq87QdjpFk6NRSLCgDTpNmO2GiXnl+FsqUjGJF27zDQ==}
+
+  '@ckeditor/ckeditor5-revision-history@47.6.1':
+    resolution: {integrity: sha512-5uOXu/ZAdhESGUp7/jjX1kZIdbw0W9AfBMWSSsibgc0tL0CQXFvjNj5/25qiknI1t4qvEmnY/FnBPa8DS94GMw==}
 
   '@ckeditor/ckeditor5-select-all@47.6.1':
     resolution: {integrity: sha512-NKhujjJ04UdM/pObi45+q6Em0fD6pQ1m+g5qLgTsTyoFUq2rFhMZqeRSPGEXlfuR5dImA7hP8uQtXNtt/GpZ7g==}
 
-  '@ckeditor/ckeditor5-paragraph@47.6.0':
-    resolution: {integrity: sha512-CxSIn9OLg/7Ol/TpwL+vZxgwwksMvR2ESI2kcSp94R8q3W8du2yoYSdPw0RzQtDuHmdGFs8JuN6xLYEU37oLBw==}
+  '@ckeditor/ckeditor5-show-blocks@47.6.1':
+    resolution: {integrity: sha512-9MdxI7TjccCOcbdlzX+SBjFvt8CsdxCgyoJxZ2NYut6QJAJ6WPjH0yVxckZXC3LSkqIPzrIOJxHc7e2n+oFFvA==}
+
+  '@ckeditor/ckeditor5-slash-command@47.6.1':
+    resolution: {integrity: sha512-BhkuMkRaehwOniGynP7Vb/f2FCJYfjF4XsfQrH1FbFPD1rCYUQFQQyz+iEKC2hEzBv55KcyEdQAlx94HREZllw==}
 
   '@ckeditor/ckeditor5-source-editing-enhanced@47.6.1':
     resolution: {integrity: sha512-MOsnED0SamPgxRvlN5J8zPpa2JyTsuopjs5kBPObbIBkR0vkGCLjqrOVpP4JTZ884q8isbt9Ex52oA+2wqlWGg==}
 
-  '@ckeditor/ckeditor5-paste-from-office@47.6.0':
-    resolution: {integrity: sha512-lS33vEq8l8MoxJe5aSC3Pem1pt+SAHI/zlf83twmBw/pb0nDjuB3HjkK+Y4Qbe5RQc/4llPJ/PN8VlR5QWyBcg==}
+  '@ckeditor/ckeditor5-source-editing@47.6.1':
+    resolution: {integrity: sha512-/NeN6KvgdlvmBzOGH1Uxk26zGti8HvvmBbHLOCzFqfXZRLHB+47BG+GtzOa82t6YnLjK7pvR23opyAApRf6zIA==}
+
+  '@ckeditor/ckeditor5-special-characters@47.6.1':
+    resolution: {integrity: sha512-O+WRAaDh3m/i3lWF+MaB0G++nBusB/uaB+koN+gwqiIfDHpGJ9HKr+KXrMZZYb0MjiGV0J5gswuwL+YvzNZ6rg==}
 
   '@ckeditor/ckeditor5-style@47.6.1':
     resolution: {integrity: sha512-WD9lzsgIk3sB+Ec/mpgbYIZXr8cRBOcDAjFndfjuSQMZRYM5kCMpIz0qpvjGp1Glz2bmeg7CwfuLDvbZSqZrfA==}
 
-  '@ckeditor/ckeditor5-remove-format@47.6.0':
-    resolution: {integrity: sha512-9+ygu79dgcynGYnQ5xkBOOwRS4DseF1gkSG4fsOfgR+53yGaDfmHrHAX4DBOrirpFPVYxBWkrbFPMY+2Wcvo4g==}
+  '@ckeditor/ckeditor5-table@47.6.1':
+    resolution: {integrity: sha512-zFJWnqL0PpdlSs8U1m5Mu/gcuoJfi0GSpDqr174dqXLtFcMfIsftVWVTbY5d4f+OKAp8LifxOg3CMvLD1YNSGA==}
 
-  '@ckeditor/ckeditor5-restricted-editing@47.6.0':
-    resolution: {integrity: sha512-vZ0ITt/ozwwUVP57GhqK7Q82yeOd3s3YgjNmNu2EFpd1apR2pYkNTJ2urghUiutVWQwBYum/H1WMwUxdOKC2tw==}
+  '@ckeditor/ckeditor5-template@47.6.1':
+    resolution: {integrity: sha512-Wd8AjACu0YEny43ZUNmOMdUhZk8G43pA5FHOIS9I98sBXIQFnB1uklYl8mAod1GUViBDPYrgqQKuY1lPnntuLg==}
+
+  '@ckeditor/ckeditor5-theme-lark@47.6.1':
+    resolution: {integrity: sha512-iaRFqt6ExGAAsOc4AfJNbMyY+jnh//gMzGendqklhQzkwV3RGzN6buRtV0Fps+pKXnpRcbqaVHWv0GOIOaG58Q==}
+
+  '@ckeditor/ckeditor5-track-changes@47.6.1':
+    resolution: {integrity: sha512-hmTT7nRmwkdhis46Xlx+gQZ5WdZI3M6KeCTD14SCqcbOi0V6DlnH17RmdPBEvEPXiDZc9HczGEEhuTMfz9/ZTg==}
 
   '@ckeditor/ckeditor5-typing@47.6.1':
     resolution: {integrity: sha512-yuMJCK6+KpYyXHxkBKRtVuOF1L42eyhUlCCq4sNFHjoJfD3q3gunmesoGIkdezMZR5RpqpGSfrOapEG9orOBTg==}
 
-  '@ckeditor/ckeditor5-select-all@47.6.0':
-    resolution: {integrity: sha512-AT6/MSUivNd3x0hYYTb8oVGtAdJ5mNJBCwM8RvjkWmX5RhqGv5xVAHt26w13mH+GNGyhot3aKVrmPgTfY7Zmqg==}
+  '@ckeditor/ckeditor5-ui@47.6.1':
+    resolution: {integrity: sha512-zBEfMSpR26rVPvc9X4KXxQd0wQG42EM+37VHdrfwJL47PFlqXTGlbsZ9BBjlElNM1mpViWSW9zpt5JdE6vtHCQ==}
 
-  '@ckeditor/ckeditor5-show-blocks@47.6.0':
-    resolution: {integrity: sha512-jh9zSrHzjKf8Wqy6Y71+0sjkoCIiLJM13aIseaNuSuxpTU9RvSxciZp2wjpixjsWg3g0iD91QV+XPrVoEkfjgw==}
+  '@ckeditor/ckeditor5-undo@47.6.1':
+    resolution: {integrity: sha512-kxckLxZHglOTv0yd7cROpZAgOQFR7uJEKy+ehGaPrPy5eMrIhUqHcDWHv4sLNJfNg1IgQrsqYNHeIaTzT38RvQ==}
+
+  '@ckeditor/ckeditor5-upload@47.6.1':
+    resolution: {integrity: sha512-GFMKl6pct+r26EQ4K2D22xokyDQIoRYQZSZFoPl4L04FFPVRuG60pA1YSNtyi7Am+T1fR3qOVBHAuXsANyeL6g==}
+
+  '@ckeditor/ckeditor5-uploadcare@47.6.1':
+    resolution: {integrity: sha512-g1rb80qlqgHdg++0aZuuPK3ZO2VwmWZSuNlH97Xbepk41giwxi14vo0YApCumAiFq3g02yRpXQQZX7vdCTViTw==}
 
   '@ckeditor/ckeditor5-utils@47.6.1':
     resolution: {integrity: sha512-gJl5DikvPjMEsv9DZmEVv6GOZEjHQN3kgaxvaAYpfg4VcT1RENHw46BfvPN/zUHsYwZlh7DxG3+o7h3M8Pzj1w==}
@@ -1343,56 +1371,14 @@ packages:
   '@ckeditor/ckeditor5-watchdog@47.6.1':
     resolution: {integrity: sha512-mHum5WRT5PKiL80UwNMXiw//s1486smeCO2sgYJKZGrqlz7cSSHDOc8iUi8Cn2YuHvTfjgRjgcZxn0u9uhr1Mw==}
 
-  '@ckeditor/ckeditor5-source-editing@47.6.0':
-    resolution: {integrity: sha512-3GD5xVrvl7ddifeF99pSPmekJhoFZmLizboBBIln6n/ZdHm4wXHCmF9ELvUSPJsxFiHASWtEVEMyHVKk6A3J8g==}
+  '@ckeditor/ckeditor5-widget@47.6.1':
+    resolution: {integrity: sha512-rURYZlY9w+qjumkQ+VQ1cO32JJbuxuGoWIPj2lTC3uFjn6kDzYB9KvNItOykBJM/V11R7sEEOWvpKlnsMmlnzg==}
 
-  '@ckeditor/ckeditor5-special-characters@47.6.0':
-    resolution: {integrity: sha512-QVkL19eOEJshIEBjBHU9XP/DXY2P1xgts7EAC4e+XRvfL/wZLzVdCZZaIC4ELdiZD1wYUGpbL+jiV/twGQxWmg==}
+  '@ckeditor/ckeditor5-word-count@47.6.1':
+    resolution: {integrity: sha512-q/8jRqtEFQ5SQEY8GsJBtatD7OdQT2f1o7KdKVDcZ4UZTQCo2hi9d2zvHEkQ7drA0LO+D3WJrHNEd+B6wk1slg==}
 
-  '@ckeditor/ckeditor5-style@47.6.0':
-    resolution: {integrity: sha512-kr2KsSXxwWwkcox85OP8FIIjhoNDhSUURErf/B7kMf28CZcsV8wNv9a0A0gMk0FQDstmtXjUEsRgdHWIzpr/IA==}
-
-  '@ckeditor/ckeditor5-table@47.6.0':
-    resolution: {integrity: sha512-JkyEJpm/WDr9U6eQ0a9wN5MUVAoqP0lk6KPnAGn64TCHAs36raeTgNEIeLbWs+1rYcl3N5IiEG+J3TNzlPpjNA==}
-
-  '@ckeditor/ckeditor5-template@47.6.0':
-    resolution: {integrity: sha512-+34l1qrQQ2gok5QFbux6Wuos3LG7ohnU6E28jzBmLgJdIW4kSqOeem98B3o2da4Xq31RAR/eFDpDt9IThPIgew==}
-
-  '@ckeditor/ckeditor5-theme-lark@47.6.0':
-    resolution: {integrity: sha512-zXZLMcTcR7dSeeybQ5qOnaAk/UicN7BzyRJEFVRKTXpKCloaMFv6YX3xneEpAdH39cY265FhfVSu/Vwvthdr0Q==}
-
-  '@ckeditor/ckeditor5-track-changes@47.6.0':
-    resolution: {integrity: sha512-vc8L+lLlgQeUJ1cjn4Ge4hg+aAfNrK3t4XojwVvRQNj0tEag1gWe/5SEgKopLsOW8nqgF+s50jLCQTM0VZ1xSQ==}
-
-  '@ckeditor/ckeditor5-typing@47.6.0':
-    resolution: {integrity: sha512-7dZylw4YGpxM4yXOO/vT9itMfJlyzkRe1+S3eC34Thh7q4pOOYERQQHuMVi4x+bifMyhR3AgpY8OdJ58R3gLqg==}
-
-  '@ckeditor/ckeditor5-ui@47.6.0':
-    resolution: {integrity: sha512-bwQyS0APV01GIRzUtp7MLn8lVK60WKRCCs1FNYnpT+oPULgF4XycXwEoARzctfCdhoda3aQulVReC/tZkUeZkw==}
-
-  '@ckeditor/ckeditor5-undo@47.6.0':
-    resolution: {integrity: sha512-sUXZCd2ZvKEKKZTzAQWaIrJfUO7E22w6+4rnx3i5H9YyUBiJF53r/O4/HJGZxshTskZe2f9nHp5pHSbFSC8UlA==}
-
-  '@ckeditor/ckeditor5-upload@47.6.0':
-    resolution: {integrity: sha512-bCjMHRfQWImu/6bmvPbOjdb3Kl+mT52SX3XKp5kmnKPESQhdfrWqVSr8H8+QpJi+0GuSxVEE3GcawPNwK+NqEg==}
-
-  '@ckeditor/ckeditor5-uploadcare@47.6.0':
-    resolution: {integrity: sha512-c6wZIeMwSR6DOOXmGlqqaj5vONPnnYBLjwC6jqmVVDHLQ0xfEerI28heJ042LNBOiKf21r6L6xxDxTTAEtgIWQ==}
-
-  '@ckeditor/ckeditor5-utils@47.6.0':
-    resolution: {integrity: sha512-+IWW2h6lGjXjLM6qlTHhB8xA7aR500KYQ7FteIn+5Aa5fT0ytyth8+AtmqpVJgXEtIK7GRCuexp1SFAcGntB/g==}
-
-  '@ckeditor/ckeditor5-watchdog@47.6.0':
-    resolution: {integrity: sha512-0oxx4Gxy5M7V3n4Iy7z6N10MzR/fwrOkFipaiisUbeMb0vHkprI4/i3i/I76iwLGYReSzu7E2Ha6+r9k5dtlfQ==}
-
-  '@ckeditor/ckeditor5-widget@47.6.0':
-    resolution: {integrity: sha512-/HMwSHiupKVDSEDFgqzfhGEksXN83bM/VTE00e1d4lP4CpNx6HAIopajPHu4dMDFLnIPPqFbtwdTKX9S/ffH3Q==}
-
-  '@ckeditor/ckeditor5-word-count@47.6.0':
-    resolution: {integrity: sha512-XDZSCXWsbbGzG4Cimbl9ArS3mKD7IllvQGYOHZgry80iqvI+V488G7baAlNV+adgdAdeCeaI0VZjdJSrQ8brUQ==}
-
-  '@codemirror/autocomplete@6.19.0':
-    resolution: {integrity: sha512-61Hfv3cF07XvUxNeC3E7jhG8XNi1Yom1G0lRC936oLnlF+jrbrv8rc/J98XlYzcsAoTVupfsf5fLej1aI8kyIg==}
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
 
   '@codemirror/commands@6.8.1':
     resolution: {integrity: sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==}
@@ -3752,8 +3738,14 @@ packages:
     resolution: {integrity: sha512-JwKSzk2kjIe7mgPK+/lyZ2QAaJcpahNAdM+hgR2HI8D0OJVkdj8Rl6J3kaLYki9pwF7P2iWnD8qVv80Lq1ABtg==}
     engines: {node: ^18.20.0 || ^20.10.0 || >=22.0.0}
     peerDependencies:
-      '@babel/core': ^7.12.0
+      '@babel/core': ^7.12.0 || ^8.0.0-beta.1
+      '@rspack/core': ^1.0.0 || ^2.0.0-0
       webpack: '>=5.61.0'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
 
   babel-loader@9.2.1:
     resolution: {integrity: sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==}
@@ -3790,8 +3782,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.7:
-    resolution: {integrity: sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==}
+  baseline-browser-mapping@2.10.8:
+    resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -3846,8 +3838,8 @@ packages:
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
-  brace-expansion@5.0.3:
-    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3914,8 +3906,8 @@ packages:
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
-  caniuse-lite@1.0.30001774:
-    resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
+  caniuse-lite@1.0.30001779:
+    resolution: {integrity: sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==}
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
@@ -3975,8 +3967,8 @@ packages:
     peerDependencies:
       ckeditor5: 47.6.1
 
-  ckeditor5@47.6.0:
-    resolution: {integrity: sha512-OynbpuohqK5XV+d5itPRMnXrFjbrTcJQp8xwFbeZzvD58aeoxVSLnM8hX2V6o3wM6OvkBdSGuKq+XhjKcRfM9g==}
+  ckeditor5@47.6.1:
+    resolution: {integrity: sha512-Za7+Dyju3RgfH4TF+zam7lvfOSr+Rd+0tABfR16HEtsARRPEmNBHYgS5nM3PZtNK4+ScliL6Ch3GFk7cd/TiOw==}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -4210,7 +4202,7 @@ packages:
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
-      webpack: ^5.104.1
+      webpack: ^5.27.0
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -4411,8 +4403,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.302:
-    resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
+  electron-to-chromium@1.5.313:
+    resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -6032,8 +6024,13 @@ packages:
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+  node-gyp@12.2.0:
+    resolution: {integrity: sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  node-releases@2.0.36:
+    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
@@ -6680,12 +6677,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
-
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
   querystringify@2.2.0:
@@ -7791,8 +7784,8 @@ packages:
       webpack-cli:
         optional: true
 
-  webpack@5.105.2:
-    resolution: {integrity: sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==}
+  webpack@5.105.4:
+    resolution: {integrity: sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -7953,26 +7946,22 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@analogjs/vite-plugin-angular@2.2.3(@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1))(@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.6)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1))':
+  '@analogjs/vite-plugin-angular@2.3.1(@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2))(@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.8)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2))':
     dependencies:
       tinyglobby: 0.2.15
       ts-morph: 21.0.1
     optionalDependencies:
-      '@angular-devkit/build-angular': 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1)
-      '@angular/build': 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.6)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1)
+      '@angular-devkit/build-angular': 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2)
+      '@angular/build': 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.8)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2)
 
-  '@analogjs/vitest-angular@2.2.3(5622f3d6cbc74853aeb2325ebf0c618b)':
+  '@analogjs/vitest-angular@2.3.1(d014764e7ce56e7bffbd51c6d32db63d)':
     dependencies:
-      '@analogjs/vite-plugin-angular': 2.2.3(@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1))(@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.6)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1))
+      '@analogjs/vite-plugin-angular': 2.3.1(@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2))(@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.8)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2))
       '@angular-devkit/architect': 0.1902.22(chokidar@4.0.3)
-      vitest: 4.0.18(@types/node@14.18.63)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1)
-
-  '@angular-devkit/architect@0.1902.20(chokidar@4.0.3)':
-    dependencies:
-      '@angular-devkit/core': 19.2.20(chokidar@4.0.3)
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - chokidar
+      '@angular-devkit/schematics': 19.2.22(chokidar@4.0.3)
+      vitest: 4.1.0(@types/node@14.18.63)(@vitest/browser-playwright@4.1.0)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
+    optionalDependencies:
+      zone.js: 0.15.1
 
   '@angular-devkit/architect@0.1902.22(chokidar@4.0.3)':
     dependencies:
@@ -7981,13 +7970,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.6))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))(webpack-cli@5.1.4)(yaml@2.8.1)':
+  '@angular-devkit/build-angular@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(sugarss@4.0.1(postcss@8.5.8))(typescript@5.5.4)(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))(webpack-cli@5.1.4)(yaml@2.8.2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1902.22(chokidar@4.0.3)
       '@angular-devkit/build-webpack': 0.1902.22(chokidar@4.0.3)(webpack-dev-server@5.2.2)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
       '@angular-devkit/core': 19.2.22(chokidar@4.0.3)
-      '@angular/build': 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.2)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1)
+      '@angular/build': 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.2)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2)
       '@angular/compiler-cli': 19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4)
       '@babel/core': 7.26.10
       '@babel/generator': 7.26.10
@@ -8000,7 +7989,7 @@ snapshots:
       '@babel/runtime': 7.26.10
       '@discoveryjs/json-ext': 0.6.3
       '@ngtools/webpack': 19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(typescript@5.5.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
-      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(yaml@2.8.1))
+      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.4.1(@types/node@14.18.63)(jiti@2.6.1)(less@4.2.2)(sass@1.85.0)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(yaml@2.8.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.20(postcss@8.5.2)
       babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
@@ -8036,13 +8025,12 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.5.4
       webpack: 5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)
-      webpack-dev-middleware: 7.4.2(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
-      webpack-dev-server: 5.2.2(webpack-cli@5.1.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
+      webpack-dev-middleware: 7.4.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
       webpack-merge: 6.0.1
       webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
     optionalDependencies:
       esbuild: 0.25.4
-      karma: 6.4.4
       ng-packagr: 19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - '@angular/compiler'
@@ -8072,11 +8060,11 @@ snapshots:
       '@angular-devkit/architect': 0.1902.22(chokidar@4.0.3)
       rxjs: 7.8.1
       webpack: 5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)
-      webpack-dev-server: 5.2.2(webpack-cli@5.1.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/core@19.2.20(chokidar@4.0.3)':
+  '@angular-devkit/core@19.2.22(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
@@ -8087,7 +8075,7 @@ snapshots:
     optionalDependencies:
       chokidar: 4.0.3
 
-  '@angular-devkit/core@19.2.22(chokidar@4.0.3)':
+  '@angular-devkit/schematics@19.2.22(chokidar@4.0.3)':
     dependencies:
       '@angular-devkit/core': 19.2.22(chokidar@4.0.3)
       jsonc-parser: 3.3.1
@@ -8103,7 +8091,7 @@ snapshots:
       '@angular/core': 19.2.20(rxjs@6.6.7)(zone.js@0.15.1)
       tslib: 2.8.1
 
-  '@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.2)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1)':
+  '@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.2)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1902.22(chokidar@4.0.3)
@@ -8152,7 +8140,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.6)(sugarss@4.0.1(postcss@8.5.6))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.1)':
+  '@angular/build@19.2.22(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(@angular/compiler@19.2.20)(@types/node@14.18.63)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(ng-packagr@19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(postcss@8.5.8)(sugarss@4.0.1(postcss@8.5.8))(terser@5.39.0)(typescript@5.5.4)(yaml@2.8.2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1902.22(chokidar@4.0.3)
@@ -8187,7 +8175,7 @@ snapshots:
       less: 4.2.2
       lmdb: 3.2.6
       ng-packagr: 19.2.2(@angular/compiler-cli@19.2.20(@angular/compiler@19.2.20)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
-      postcss: 8.5.6
+      postcss: 8.5.8
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -9457,15 +9445,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@ckeditor/ckeditor5-adapter-ckfinder@47.6.0':
+  '@ckeditor/ckeditor5-adapter-ckfinder@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-upload': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-ai@47.6.0':
+  '@ckeditor/ckeditor5-ai@47.6.1':
     dependencies:
       '@aws-sdk/client-bedrock-runtime': 3.994.0
       '@ckeditor/ckeditor5-clipboard': 47.6.1
@@ -9496,7 +9484,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@ckeditor/ckeditor5-alignment@47.6.0':
+  '@ckeditor/ckeditor5-alignment@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-autoformat@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.1
       '@ckeditor/ckeditor5-engine': 47.6.1
@@ -9507,14 +9505,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-autoformat@47.6.0':
+  '@ckeditor/ckeditor5-autosave@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
@@ -9530,7 +9526,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-basic-styles@47.6.0':
+  '@ckeditor/ckeditor5-block-quote@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-bookmark@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-link': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-case-change@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.1
       '@ckeditor/ckeditor5-icons': 47.6.1
@@ -9538,39 +9558,23 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-block-quote@47.6.0':
+  '@ckeditor/ckeditor5-ckbox@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      blurhash: 2.0.5
+      ckeditor5: 47.6.1
+      es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-bookmark@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-link': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-case-change@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-ckbox@47.6.0':
+  '@ckeditor/ckeditor5-ckfinder@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.1
       '@ckeditor/ckeditor5-icons': 47.6.1
@@ -9581,62 +9585,49 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-ckfinder@47.6.0':
+  '@ckeditor/ckeditor5-clipboard@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-cloud-services@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-clipboard@47.6.0':
+  '@ckeditor/ckeditor5-code-block@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      es-toolkit: 1.39.5
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
   '@ckeditor/ckeditor5-collaboration-core@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-code-block@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-collaboration-core@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-comments': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-link': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-track-changes': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
+      '@ckeditor/ckeditor5-comments': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-link': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-track-changes': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
       '@types/luxon': 3.6.2
       ckeditor5: 47.6.1
       diff: 8.0.3
@@ -9668,7 +9659,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-core@47.6.0':
+  '@ckeditor/ckeditor5-core@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-watchdog': 47.6.1
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-dev-bump-year@54.5.0':
     dependencies:
       glob: 13.0.6
 
@@ -9764,8 +9763,8 @@ snapshots:
       raw-loader: 4.0.2(webpack@5.105.4)
       shelljs: 0.10.0
       simple-git: 3.33.0
-      style-loader: 4.0.0(webpack@5.105.2)
-      terser-webpack-plugin: 5.3.16(webpack@5.105.2)
+      style-loader: 4.0.0(webpack@5.105.4)
+      terser-webpack-plugin: 5.4.0(webpack@5.105.4)
       through2: 4.0.2
       upath: 2.0.1
     transitivePeerDependencies:
@@ -9790,7 +9789,17 @@ snapshots:
       ckeditor5: 47.6.1
       es-toolkit: 1.39.5
 
-  '@ckeditor/ckeditor5-easy-image@47.6.0':
+  '@ckeditor/ckeditor5-easy-image@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-editor-balloon@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.1
       '@ckeditor/ckeditor5-engine': 47.6.1
@@ -9798,74 +9807,81 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
-  '@ckeditor/ckeditor5-editor-balloon@47.6.0':
+  '@ckeditor/ckeditor5-editor-classic@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-editor-decoupled@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-editor-inline@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-editor-multi-root@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-email@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-export-inline-styles': 47.6.1
+      '@ckeditor/ckeditor5-font': 47.6.1
+      '@ckeditor/ckeditor5-html-support': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-table': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
   '@ckeditor/ckeditor5-emoji@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-mention': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
+      fuzzysort: 3.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-editor-decoupled@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-editor-inline@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-editor-multi-root@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-email@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-export-inline-styles': 47.6.0
-      '@ckeditor/ckeditor5-font': 47.6.0
-      '@ckeditor/ckeditor5-html-support': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-emoji@47.6.0':
+  '@ckeditor/ckeditor5-engine@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-utils': 47.6.1
       es-toolkit: 1.39.5
@@ -9889,36 +9905,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-engine@47.6.0':
+  '@ckeditor/ckeditor5-export-inline-styles@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-enter@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-
-  '@ckeditor/ckeditor5-essentials@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-select-all': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-undo': 47.6.0
-      ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-export-inline-styles@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       specificity: 0.4.1
 
   '@ckeditor/ckeditor5-export-pdf@47.6.1':
@@ -9930,6 +9922,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.6.1
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-export-word@47.6.1':
     dependencies:
@@ -9946,137 +9940,137 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-find-and-replace@47.6.0':
+  '@ckeditor/ckeditor5-find-and-replace@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-font@47.6.0':
+  '@ckeditor/ckeditor5-font@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-footnotes@47.6.0':
+  '@ckeditor/ckeditor5-footnotes@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-format-painter@47.6.0':
+  '@ckeditor/ckeditor5-format-painter@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-fullscreen@47.6.0':
+  '@ckeditor/ckeditor5-fullscreen@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-classic': 47.6.0
-      '@ckeditor/ckeditor5-editor-decoupled': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-editor-classic': 47.6.1
+      '@ckeditor/ckeditor5-editor-decoupled': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-heading@47.6.0':
+  '@ckeditor/ckeditor5-heading@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-paragraph': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-paragraph': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-highlight@47.6.0':
+  '@ckeditor/ckeditor5-highlight@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-horizontal-line@47.6.0':
+  '@ckeditor/ckeditor5-horizontal-line@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-html-embed@47.6.0':
+  '@ckeditor/ckeditor5-html-embed@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-html-support@47.6.0':
+  '@ckeditor/ckeditor5-html-support@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-remove-format': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-heading': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-remove-format': 47.6.1
+      '@ckeditor/ckeditor5-table': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-icons@47.6.0': {}
+  '@ckeditor/ckeditor5-icons@47.6.1': {}
 
-  '@ckeditor/ckeditor5-image@47.6.0':
+  '@ckeditor/ckeditor5-image@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-undo': 47.6.0
-      '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-undo': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
@@ -10092,31 +10086,33 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.6.1
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
-
-  '@ckeditor/ckeditor5-indent@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-integrations-common@2.2.3(ckeditor5@47.6.0)':
+  '@ckeditor/ckeditor5-indent@47.6.1':
     dependencies:
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-heading': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
-  '@ckeditor/ckeditor5-language@47.6.0':
+  '@ckeditor/ckeditor5-integrations-common@2.2.4(ckeditor5@47.6.1)':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.1
+
+  '@ckeditor/ckeditor5-language@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -10130,18 +10126,18 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-link@47.6.0':
+  '@ckeditor/ckeditor5-link@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
@@ -10156,23 +10152,47 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-list@47.6.0':
+  '@ckeditor/ckeditor5-list@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-font': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-font': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-markdown-gfm@47.6.0':
+  '@ckeditor/ckeditor5-markdown-gfm@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@types/hast': 3.0.4
+      ckeditor5: 47.6.1
+      hast-util-from-dom: 5.0.1
+      hast-util-to-html: 9.0.5
+      hast-util-to-mdast: 10.1.2
+      hastscript: 9.0.1
+      rehype-dom-parse: 5.0.2
+      rehype-dom-stringify: 4.0.2
+      rehype-remark: 10.0.1
+      remark-breaks: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-media-embed@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-clipboard': 47.6.1
       '@ckeditor/ckeditor5-core': 47.6.1
@@ -10187,18 +10207,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-media-embed@47.6.0':
+  '@ckeditor/ckeditor5-mention@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-undo': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
@@ -10213,42 +10229,36 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 47.6.1
       ckeditor5: 47.6.1
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-minimap@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-operations-compressor@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-mention': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-minimap@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-operations-compressor@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
       protobufjs: 7.5.4
 
-  '@ckeditor/ckeditor5-page-break@47.6.0':
+  '@ckeditor/ckeditor5-page-break@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-pagination@47.6.1':
     dependencies:
@@ -10260,13 +10270,23 @@ snapshots:
       ckeditor5: 47.6.1
       es-toolkit: 1.39.5
 
-  '@ckeditor/ckeditor5-paragraph@47.6.0':
+  '@ckeditor/ckeditor5-paragraph@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+
+  '@ckeditor/ckeditor5-paste-from-office-enhanced@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.1
       '@ckeditor/ckeditor5-engine': 47.6.1
       '@ckeditor/ckeditor5-paste-from-office': 47.6.1
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-paste-from-office@47.6.1':
     dependencies:
@@ -10274,37 +10294,42 @@ snapshots:
       '@ckeditor/ckeditor5-core': 47.6.1
       '@ckeditor/ckeditor5-engine': 47.6.1
       ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
-  '@ckeditor/ckeditor5-paste-from-office@47.6.0':
+  '@ckeditor/ckeditor5-real-time-collaboration@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-real-time-collaboration@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor-cloud-services-collaboration': 53.0.3(@ckeditor/ckeditor5-utils@47.6.0)(ckeditor5@47.6.0)
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
-      '@ckeditor/ckeditor5-comments': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-operations-compressor': 47.6.0
-      '@ckeditor/ckeditor5-revision-history': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-track-changes': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      ckeditor5-collaboration: 47.6.0
+      '@ckeditor/ckeditor-cloud-services-collaboration': 53.0.3(@ckeditor/ckeditor5-utils@47.6.1)(ckeditor5@47.6.1)
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-comments': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-operations-compressor': 47.6.1
+      '@ckeditor/ckeditor5-revision-history': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-track-changes': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+      ckeditor5-collaboration: 47.6.1
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@ckeditor/ckeditor5-remove-format@47.6.0':
+  '@ckeditor/ckeditor5-remove-format@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-restricted-editing@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.1
       '@ckeditor/ckeditor5-engine': 47.6.1
@@ -10312,27 +10337,20 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.6.1
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
-  '@ckeditor/ckeditor5-restricted-editing@47.6.0':
+  '@ckeditor/ckeditor5-revision-history@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-revision-history@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-autosave': 47.6.0
-      '@ckeditor/ckeditor5-collaboration-core': 47.6.0
-      '@ckeditor/ckeditor5-comments': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-classic': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-autosave': 47.6.1
+      '@ckeditor/ckeditor5-collaboration-core': 47.6.1
+      '@ckeditor/ckeditor5-comments': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-editor-classic': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
       '@types/luxon': 3.6.2
       ckeditor5: 47.6.1
       ckeditor5-collaboration: 47.6.1
@@ -10341,33 +10359,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-select-all@47.6.0':
+  '@ckeditor/ckeditor5-select-all@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
 
-  '@ckeditor/ckeditor5-show-blocks@47.6.0':
+  '@ckeditor/ckeditor5-show-blocks@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-slash-command@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-mention': 47.6.0
-      '@ckeditor/ckeditor5-style': 47.6.0
-      '@ckeditor/ckeditor5-template': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-heading': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-mention': 47.6.1
+      '@ckeditor/ckeditor5-style': 47.6.1
+      '@ckeditor/ckeditor5-template': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-source-editing-enhanced@47.6.1':
     dependencies:
@@ -10386,7 +10408,18 @@ snapshots:
       '@codemirror/view': 6.40.0
       ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-source-editing@47.6.0':
+  '@ckeditor/ckeditor5-source-editing@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-special-characters@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.1
       '@ckeditor/ckeditor5-icons': 47.6.1
@@ -10394,39 +10427,36 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.6.1
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
-  '@ckeditor/ckeditor5-special-characters@47.6.0':
+  '@ckeditor/ckeditor5-style@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-
-  '@ckeditor/ckeditor5-style@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-html-support': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-html-support': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-table': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
-  '@ckeditor/ckeditor5-table@47.6.0':
+  '@ckeditor/ckeditor5-table@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-template@47.6.1':
     dependencies:
@@ -10436,7 +10466,11 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
 
-  '@ckeditor/ckeditor5-theme-lark@47.6.0':
+  '@ckeditor/ckeditor5-theme-lark@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-ui': 47.6.1
+
+  '@ckeditor/ckeditor5-track-changes@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-clipboard': 47.6.1
       '@ckeditor/ckeditor5-code-block': 47.6.1
@@ -10467,14 +10501,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-typing@47.6.0':
+  '@ckeditor/ckeditor5-typing@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
       es-toolkit: 1.39.5
 
-  '@ckeditor/ckeditor5-ui@47.6.0':
+  '@ckeditor/ckeditor5-ui@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@types/color-convert': 2.0.4
+      color-convert: 3.1.0
+      color-parse: 2.0.2
+      es-toolkit: 1.39.5
+      vanilla-colorful: 0.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-undo@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.1
       '@ckeditor/ckeditor5-engine': 47.6.1
@@ -10482,28 +10531,20 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.6.1
       '@ckeditor/ckeditor5-utils': 47.6.1
 
-  '@ckeditor/ckeditor5-undo@47.6.0':
+  '@ckeditor/ckeditor5-upload@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
 
-  '@ckeditor/ckeditor5-upload@47.6.0':
+  '@ckeditor/ckeditor5-uploadcare@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-
-  '@ckeditor/ckeditor5-uploadcare@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
       '@uploadcare/file-uploader': 1.24.5
       '@uploadcare/upload-client': 6.14.3
       ckeditor5: 47.6.1
@@ -10511,7 +10552,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ckeditor/ckeditor5-utils@47.6.0':
+  '@ckeditor/ckeditor5-utils@47.6.1':
+    dependencies:
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-watchdog@47.6.1':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.1
       '@ckeditor/ckeditor5-editor-multi-root': 47.6.1
@@ -10521,32 +10569,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-watchdog@47.6.0':
+  '@ckeditor/ckeditor5-widget@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
       es-toolkit: 1.39.5
 
-  '@ckeditor/ckeditor5-widget@47.6.0':
+  '@ckeditor/ckeditor5-word-count@47.6.1':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      ckeditor5: 47.6.1
       es-toolkit: 1.39.5
-
-  '@ckeditor/ckeditor5-word-count@47.6.0':
-    dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
-      es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@codemirror/autocomplete@6.20.1':
     dependencies:
@@ -10661,7 +10703,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.14.2
+      qs: 6.15.0
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
@@ -12286,7 +12328,7 @@ snapshots:
   '@tufjs/models@4.1.0':
     dependencies:
       '@tufjs/canonical-json': 2.0.0
-      minimatch: 9.0.9
+      minimatch: 10.2.4
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -12498,11 +12540,10 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       '@typescript-eslint/visitor-keys': 8.57.0
       debug: 4.4.3(supports-color@8.1.1)
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 9.0.9
-      semver: 7.7.3
-      ts-api-utils: 2.1.0(typescript@5.5.4)
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
@@ -12728,20 +12769,20 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.2(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2)
+      webpack: 5.105.4(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.2(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2)
+      webpack: 5.105.4(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.2)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.2(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2)
+      webpack: 5.105.4(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
     optionalDependencies:
-      webpack-dev-server: 5.2.2(webpack-cli@5.1.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -12877,7 +12918,7 @@ snapshots:
   autoprefixer@10.4.20(postcss@8.5.2):
     dependencies:
       browserslist: 4.28.1
-      caniuse-lite: 1.0.30001774
+      caniuse-lite: 1.0.30001779
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -12900,7 +12941,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.10
       find-up: 5.0.0
-      webpack: 5.105.2(webpack-cli@5.1.4)
+    optionalDependencies:
+      webpack: 5.105.4(webpack-cli@5.1.4)
 
   babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)):
     dependencies:
@@ -12941,7 +12983,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.7: {}
+  baseline-browser-mapping@2.10.8: {}
 
   batch@0.6.1: {}
 
@@ -12978,23 +13020,6 @@ snapshots:
 
   blurhash@2.0.5: {}
 
-  body-parser@1.20.3:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      http-errors: 2.0.0
-      iconv-lite: 0.4.24
-      on-finished: 2.4.1
-      qs: 6.14.2
-      raw-body: 2.5.2
-      type-is: 1.6.18
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   body-parser@1.20.4:
     dependencies:
       bytes: 3.1.2
@@ -13005,7 +13030,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.0
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -13030,7 +13055,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.3:
+  brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
 
@@ -13040,18 +13065,10 @@ snapshots:
 
   browser-stdout@1.3.1: {}
 
-  browserslist@4.26.3:
-    dependencies:
-      baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001774
-      electron-to-chromium: 1.5.302
-      node-releases: 2.0.27
-      update-browserslist-db: 1.2.3(browserslist@4.26.3)
-
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.7
-      caniuse-lite: 1.0.30001778
+      baseline-browser-mapping: 2.10.8
+      caniuse-lite: 1.0.30001779
       electron-to-chromium: 1.5.313
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
@@ -13121,11 +13138,11 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.28.1
-      caniuse-lite: 1.0.30001778
+      caniuse-lite: 1.0.30001779
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001774: {}
+  caniuse-lite@1.0.30001779: {}
 
   caseless@0.12.0: {}
 
@@ -13210,69 +13227,69 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  ckeditor5@47.6.0:
+  ckeditor5@47.6.1:
     dependencies:
-      '@ckeditor/ckeditor5-adapter-ckfinder': 47.6.0
-      '@ckeditor/ckeditor5-alignment': 47.6.0
-      '@ckeditor/ckeditor5-autoformat': 47.6.0
-      '@ckeditor/ckeditor5-autosave': 47.6.0
-      '@ckeditor/ckeditor5-basic-styles': 47.6.0
-      '@ckeditor/ckeditor5-block-quote': 47.6.0
-      '@ckeditor/ckeditor5-bookmark': 47.6.0
-      '@ckeditor/ckeditor5-ckbox': 47.6.0
-      '@ckeditor/ckeditor5-ckfinder': 47.6.0
-      '@ckeditor/ckeditor5-clipboard': 47.6.0
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
-      '@ckeditor/ckeditor5-code-block': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-easy-image': 47.6.0
-      '@ckeditor/ckeditor5-editor-balloon': 47.6.0
-      '@ckeditor/ckeditor5-editor-classic': 47.6.0
-      '@ckeditor/ckeditor5-editor-decoupled': 47.6.0
-      '@ckeditor/ckeditor5-editor-inline': 47.6.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0
-      '@ckeditor/ckeditor5-emoji': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-essentials': 47.6.0
-      '@ckeditor/ckeditor5-find-and-replace': 47.6.0
-      '@ckeditor/ckeditor5-font': 47.6.0
-      '@ckeditor/ckeditor5-fullscreen': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-highlight': 47.6.0
-      '@ckeditor/ckeditor5-horizontal-line': 47.6.0
-      '@ckeditor/ckeditor5-html-embed': 47.6.0
-      '@ckeditor/ckeditor5-html-support': 47.6.0
-      '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-indent': 47.6.0
-      '@ckeditor/ckeditor5-language': 47.6.0
-      '@ckeditor/ckeditor5-link': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-markdown-gfm': 47.6.0
-      '@ckeditor/ckeditor5-media-embed': 47.6.0
-      '@ckeditor/ckeditor5-mention': 47.6.0
-      '@ckeditor/ckeditor5-minimap': 47.6.0
-      '@ckeditor/ckeditor5-page-break': 47.6.0
-      '@ckeditor/ckeditor5-paragraph': 47.6.0
-      '@ckeditor/ckeditor5-paste-from-office': 47.6.0
-      '@ckeditor/ckeditor5-remove-format': 47.6.0
-      '@ckeditor/ckeditor5-restricted-editing': 47.6.0
-      '@ckeditor/ckeditor5-select-all': 47.6.0
-      '@ckeditor/ckeditor5-show-blocks': 47.6.0
-      '@ckeditor/ckeditor5-source-editing': 47.6.0
-      '@ckeditor/ckeditor5-special-characters': 47.6.0
-      '@ckeditor/ckeditor5-style': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-undo': 47.6.0
-      '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      '@ckeditor/ckeditor5-watchdog': 47.6.0
-      '@ckeditor/ckeditor5-widget': 47.6.0
-      '@ckeditor/ckeditor5-word-count': 47.6.0
+      '@ckeditor/ckeditor5-adapter-ckfinder': 47.6.1
+      '@ckeditor/ckeditor5-alignment': 47.6.1
+      '@ckeditor/ckeditor5-autoformat': 47.6.1
+      '@ckeditor/ckeditor5-autosave': 47.6.1
+      '@ckeditor/ckeditor5-basic-styles': 47.6.1
+      '@ckeditor/ckeditor5-block-quote': 47.6.1
+      '@ckeditor/ckeditor5-bookmark': 47.6.1
+      '@ckeditor/ckeditor5-ckbox': 47.6.1
+      '@ckeditor/ckeditor5-ckfinder': 47.6.1
+      '@ckeditor/ckeditor5-clipboard': 47.6.1
+      '@ckeditor/ckeditor5-cloud-services': 47.6.1
+      '@ckeditor/ckeditor5-code-block': 47.6.1
+      '@ckeditor/ckeditor5-core': 47.6.1
+      '@ckeditor/ckeditor5-easy-image': 47.6.1
+      '@ckeditor/ckeditor5-editor-balloon': 47.6.1
+      '@ckeditor/ckeditor5-editor-classic': 47.6.1
+      '@ckeditor/ckeditor5-editor-decoupled': 47.6.1
+      '@ckeditor/ckeditor5-editor-inline': 47.6.1
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.1
+      '@ckeditor/ckeditor5-emoji': 47.6.1
+      '@ckeditor/ckeditor5-engine': 47.6.1
+      '@ckeditor/ckeditor5-enter': 47.6.1
+      '@ckeditor/ckeditor5-essentials': 47.6.1
+      '@ckeditor/ckeditor5-find-and-replace': 47.6.1
+      '@ckeditor/ckeditor5-font': 47.6.1
+      '@ckeditor/ckeditor5-fullscreen': 47.6.1
+      '@ckeditor/ckeditor5-heading': 47.6.1
+      '@ckeditor/ckeditor5-highlight': 47.6.1
+      '@ckeditor/ckeditor5-horizontal-line': 47.6.1
+      '@ckeditor/ckeditor5-html-embed': 47.6.1
+      '@ckeditor/ckeditor5-html-support': 47.6.1
+      '@ckeditor/ckeditor5-icons': 47.6.1
+      '@ckeditor/ckeditor5-image': 47.6.1
+      '@ckeditor/ckeditor5-indent': 47.6.1
+      '@ckeditor/ckeditor5-language': 47.6.1
+      '@ckeditor/ckeditor5-link': 47.6.1
+      '@ckeditor/ckeditor5-list': 47.6.1
+      '@ckeditor/ckeditor5-markdown-gfm': 47.6.1
+      '@ckeditor/ckeditor5-media-embed': 47.6.1
+      '@ckeditor/ckeditor5-mention': 47.6.1
+      '@ckeditor/ckeditor5-minimap': 47.6.1
+      '@ckeditor/ckeditor5-page-break': 47.6.1
+      '@ckeditor/ckeditor5-paragraph': 47.6.1
+      '@ckeditor/ckeditor5-paste-from-office': 47.6.1
+      '@ckeditor/ckeditor5-remove-format': 47.6.1
+      '@ckeditor/ckeditor5-restricted-editing': 47.6.1
+      '@ckeditor/ckeditor5-select-all': 47.6.1
+      '@ckeditor/ckeditor5-show-blocks': 47.6.1
+      '@ckeditor/ckeditor5-source-editing': 47.6.1
+      '@ckeditor/ckeditor5-special-characters': 47.6.1
+      '@ckeditor/ckeditor5-style': 47.6.1
+      '@ckeditor/ckeditor5-table': 47.6.1
+      '@ckeditor/ckeditor5-theme-lark': 47.6.1
+      '@ckeditor/ckeditor5-typing': 47.6.1
+      '@ckeditor/ckeditor5-ui': 47.6.1
+      '@ckeditor/ckeditor5-undo': 47.6.1
+      '@ckeditor/ckeditor5-upload': 47.6.1
+      '@ckeditor/ckeditor5-utils': 47.6.1
+      '@ckeditor/ckeditor5-watchdog': 47.6.1
+      '@ckeditor/ckeditor5-widget': 47.6.1
+      '@ckeditor/ckeditor5-word-count': 47.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -13411,6 +13428,10 @@ snapshots:
     dependencies:
       is-what: 3.14.1
 
+  copy-anything@3.0.5:
+    dependencies:
+      is-what: 4.1.16
+
   copy-webpack-plugin@12.0.2(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)):
     dependencies:
       fast-glob: 3.3.3
@@ -13473,23 +13494,10 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.8)
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
-      semver: 7.7.3
-      webpack: 5.105.2(webpack-cli@5.1.4)
+      semver: 7.7.4
+      webpack: 5.105.4(webpack-cli@5.1.4)
 
   css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
-      postcss-value-parser: 4.2.0
-      semver: 7.7.3
-    optionalDependencies:
-      webpack: 5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)
-
-  css-loader@7.1.2(webpack@5.105.4):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.2)
       postcss: 8.5.2
@@ -13500,7 +13508,20 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.105.2(webpack-cli@5.1.4)
+      webpack: 5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)
+
+  css-loader@7.1.4(webpack@5.105.4):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.8)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.8)
+      postcss-modules-scope: 3.2.1(postcss@8.5.8)
+      postcss-modules-values: 4.0.0(postcss@8.5.8)
+      postcss-value-parser: 4.2.0
+      semver: 7.7.4
+    optionalDependencies:
+      webpack: 5.105.4(webpack-cli@5.1.4)
 
   css-select@5.2.2:
     dependencies:
@@ -13733,7 +13754,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.302: {}
+  electron-to-chromium@1.5.313: {}
 
   emoji-regex@10.6.0: {}
 
@@ -13825,7 +13846,7 @@ snapshots:
       esbuild: 0.27.4
       get-tsconfig: 4.13.6
       loader-utils: 2.0.4
-      webpack: 5.105.2(webpack-cli@5.1.4)
+      webpack: 5.105.4(webpack-cli@5.1.4)
       webpack-sources: 1.4.3
 
   esbuild-wasm@0.25.4: {}
@@ -14117,7 +14138,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -14381,34 +14402,15 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.9
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
   glob@13.0.6:
     dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.1.1
       minimatch: 10.2.4
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
-
-  glob@13.0.0:
-    dependencies:
-      minimatch: 10.2.4
-      minipass: 7.1.2
-      path-scurry: 2.0.0
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    optional: true
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   global-dirs@3.0.1:
     dependencies:
@@ -14954,39 +14956,6 @@ snapshots:
     dependencies:
       source-map-support: 0.5.21
 
-  karma@6.4.4:
-    dependencies:
-      '@colors/colors': 1.5.0
-      body-parser: 1.20.4
-      braces: 3.0.3
-      chokidar: 3.6.0
-      connect: 3.7.0
-      di: 0.0.1
-      dom-serialize: 2.2.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      http-proxy: 1.18.1(debug@4.4.3)
-      isbinaryfile: 4.0.10
-      lodash: 4.17.23
-      log4js: 6.9.1
-      mime: 2.6.0
-      minimatch: 3.1.5
-      mkdirp: 0.5.6
-      qjobs: 1.2.0
-      range-parser: 1.2.1
-      rimraf: 3.0.2
-      socket.io: 4.8.3
-      source-map: 0.6.1
-      tmp: 0.2.5
-      ua-parser-js: 0.7.41
-      yargs: 16.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   keyux@0.7.2: {}
 
   keyv@4.5.4:
@@ -15163,17 +15132,6 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
-
-  log4js@6.9.1:
-    dependencies:
-      date-format: 4.0.14
-      debug: 4.4.3(supports-color@8.1.1)
-      flatted: 3.4.1
-      rfdc: 1.4.1
-      streamroller: 3.1.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   long@5.3.2: {}
 
@@ -15635,17 +15593,17 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mini-css-extract-plugin@2.10.1(webpack@5.105.4):
+    dependencies:
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      webpack: 5.105.4(webpack-cli@5.1.4)
+
   mini-css-extract-plugin@2.9.2(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
       webpack: 5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)
-
-  mini-css-extract-plugin@2.9.2(webpack@5.105.4):
-    dependencies:
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      webpack: 5.105.2(webpack-cli@5.1.4)
 
   minimalistic-assert@1.0.1: {}
 
@@ -15836,14 +15794,29 @@ snapshots:
       make-fetch-happen: 14.0.3
       nopt: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.3
+      semver: 7.7.4
       tar: 7.5.11
       tinyglobby: 0.2.15
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  node-releases@2.0.27: {}
+  node-gyp@12.2.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 15.0.4
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.7.4
+      tar: 7.5.11
+      tinyglobby: 0.2.15
+      which: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  node-releases@2.0.36: {}
 
   nopt@8.1.0:
     dependencies:
@@ -16077,15 +16050,14 @@ snapshots:
       '@npmcli/run-script': 10.0.4
       cacache: 20.0.3
       fs-minipass: 3.0.3
-      minipass: 7.1.2
-      npm-package-arg: 13.0.1
-      npm-packlist: 10.0.2
-      npm-pick-manifest: 11.0.1
-      npm-registry-fetch: 19.0.0
-      proc-log: 5.0.0
-      promise-retry: 2.0.1
-      sigstore: 4.0.0
-      ssri: 12.0.0
+      minipass: 7.1.3
+      npm-package-arg: 13.0.2
+      npm-packlist: 10.0.4
+      npm-pick-manifest: 11.0.3
+      npm-registry-fetch: 19.1.1
+      proc-log: 6.1.0
+      sigstore: 4.1.0
+      ssri: 13.0.1
       tar: 7.5.11
     transitivePeerDependencies:
       - supports-color
@@ -16260,8 +16232,8 @@ snapshots:
       loader-utils: 2.0.4
       postcss: 8.5.8
       schema-utils: 3.3.0
-      semver: 7.7.3
-      webpack: 5.105.2(webpack-cli@5.1.4)
+      semver: 7.7.4
+      webpack: 5.105.4(webpack-cli@5.1.4)
 
   postcss-loader@8.1.1(postcss@8.5.2)(typescript@5.5.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)):
     dependencies:
@@ -16281,7 +16253,7 @@ snapshots:
       postcss: 8.5.8
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.105.2(webpack-cli@5.1.4)
+      webpack: 5.105.4(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
 
@@ -16536,11 +16508,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.2:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.14.2:
+  qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
 
@@ -16561,7 +16529,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.2(webpack-cli@5.1.4)
+      webpack: 5.105.4(webpack-cli@5.1.4)
 
   read-cache@1.0.0:
     dependencies:
@@ -17240,11 +17208,11 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.2(webpack-cli@5.1.4)
+      webpack: 5.105.4(webpack-cli@5.1.4)
 
   style-loader@4.0.0(webpack@5.105.4):
     dependencies:
-      webpack: 5.105.2(webpack-cli@5.1.4)
+      webpack: 5.105.4(webpack-cli@5.1.4)
 
   style-mod@4.1.3: {}
 
@@ -17290,25 +17258,23 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  terser-webpack-plugin@5.3.16(esbuild@0.25.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.4.0(esbuild@0.25.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 7.0.4
-      terser: 5.44.0
+      terser: 5.46.0
       webpack: 5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)
     optionalDependencies:
       esbuild: 0.25.4
 
-  terser-webpack-plugin@5.3.16(webpack@5.105.2):
+  terser-webpack-plugin@5.4.0(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 7.0.4
-      terser: 5.44.0
-      webpack: 5.105.2(webpack-cli@5.1.4)
+      terser: 5.46.0
+      webpack: 5.105.4(webpack-cli@5.1.4)
 
   terser@5.39.0:
     dependencies:
@@ -17393,7 +17359,7 @@ snapshots:
       semver: 7.7.4
       source-map: 0.7.6
       typescript: 5.5.4
-      webpack: 5.105.2(webpack-cli@5.1.4)
+      webpack: 5.105.4(webpack-cli@5.1.4)
 
   ts-morph@21.0.1:
     dependencies:
@@ -17545,12 +17511,6 @@ snapshots:
 
   upath@2.0.1: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.26.3):
-    dependencies:
-      browserslist: 4.26.3
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -17698,12 +17658,12 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.105.2(webpack-cli@5.1.4)
+      webpack: 5.105.4(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
-      webpack-dev-server: 5.2.2(webpack-cli@5.1.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
 
-  webpack-dev-middleware@7.4.2(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)):
+  webpack-dev-middleware@7.4.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.56.11(tslib@2.8.1)
@@ -17713,8 +17673,10 @@ snapshots:
       schema-utils: 4.3.3
     optionalDependencies:
       webpack: 5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)
+    transitivePeerDependencies:
+      - tslib
 
-  webpack-dev-server@5.2.2(webpack-cli@5.1.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)):
+  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -17742,11 +17704,11 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.2(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
-      ws: 8.18.3
+      webpack-dev-middleware: 7.4.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
+      ws: 8.19.0
     optionalDependencies:
       webpack: 5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -17802,17 +17764,17 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.4.0(esbuild@0.25.4)(webpack@5.105.0(esbuild@0.25.4)(webpack-cli@5.1.4))
       watchpack: 2.5.1
-      webpack-sources: 3.3.3
+      webpack-sources: 3.3.4
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.2)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.2)(webpack@5.105.4)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
       - uglify-js
 
-  webpack@5.105.2(webpack-cli@5.1.4):
+  webpack@5.105.4(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -17820,11 +17782,11 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.1
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
+      enhanced-resolve: 5.20.0
       es-module-lexer: 2.0.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -17836,7 +17798,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(webpack@5.105.2)
+      terser-webpack-plugin: 5.4.0(webpack@5.105.4)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -24,18 +24,13 @@ describe( 'CKEditorComponent', () => {
 	} );
 
 	describe( 'component initialization', () => {
-		let CKEDITOR_VERSION: string | undefined;
-
 		beforeEach( () => {
 			vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
-
-			CKEDITOR_VERSION = ( window as any ).CKEDITOR_VERSION;
 		} );
 
 		afterEach( () => {
 			fixture.destroy();
-
-			( window as any ).CKEDITOR_VERSION = CKEDITOR_VERSION;
+			vi.unstubAllGlobals();
 		} );
 
 		it( 'should create', () => {
@@ -47,7 +42,7 @@ describe( 'CKEditorComponent', () => {
 		} );
 
 		it( 'should print a warning if the "window.CKEDITOR_VERSION" variable is not available', () => {
-			delete ( window as any ).CKEDITOR_VERSION;
+			vi.stubGlobal( 'CKEDITOR_VERSION', undefined );
 
 			fixture = TestBed.createComponent( CKEditorComponent );
 			component = fixture.componentInstance;
@@ -57,7 +52,7 @@ describe( 'CKEditorComponent', () => {
 		} );
 
 		it( 'should print a warning if using CKEditor 5 in version lower than 37', () => {
-			( window as any ).CKEDITOR_VERSION = '30.0.0';
+			vi.stubGlobal( 'CKEDITOR_VERSION', '30.0.0' );
 
 			fixture = TestBed.createComponent( CKEditorComponent );
 			component = fixture.componentInstance;
@@ -69,7 +64,7 @@ describe( 'CKEditorComponent', () => {
 		} );
 
 		it( 'should not print any warning if using CKEditor 5 in version 37 or higher', () => {
-			( window as any ).CKEDITOR_VERSION = '42.0.0';
+			vi.stubGlobal( 'CKEDITOR_VERSION', '42.0.0' );
 
 			fixture = TestBed.createComponent( CKEditorComponent );
 			component = fixture.componentInstance;
@@ -147,7 +142,7 @@ describe( 'CKEditorComponent', () => {
 				component = commercialFixture.componentInstance;
 				component.editor = MockEditor as any;
 
-				( window as any ).CKEDITOR_VERSION = '44.0.0';
+				vi.stubGlobal( 'CKEDITOR_VERSION', '44.0.0' );
 
 				component.config.licenseKey = 'foo';
 				commercialFixture.detectChanges();

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -23,6 +23,10 @@ describe( 'CKEditorComponent', () => {
 		} ).compileComponents();
 	} );
 
+	afterEach( () => {
+		vi.unstubAllGlobals();
+	} );
+
 	describe( 'component initialization', () => {
 		beforeEach( () => {
 			vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
@@ -175,6 +179,42 @@ describe( 'CKEditorComponent', () => {
 
 				expect( component.data ).toEqual( 'foo' );
 				expect( component.editorInstance!.data.get() ).toEqual( '<p>foo</p>' );
+			} );
+
+			it( 'should pass config with initialData when using CKEditor 5 v47', async () => {
+				vi.stubGlobal( 'CKEDITOR_VERSION', '47.0.0' );
+
+				const localFixture = TestBed.createComponent( CKEditorComponent );
+				const localComponent = localFixture.componentInstance;
+				localComponent.editor = MockEditor as any;
+				localComponent.data = 'foo';
+
+				localFixture.detectChanges();
+
+				await waitCycle();
+
+				expect( ( localComponent.editorInstance as any ).config.initialData ).toBe( 'foo' );
+				expect( ( localComponent.editorInstance as any ).config.roots ).toBeUndefined();
+
+				localFixture.destroy();
+			} );
+
+			it( 'should pass config with roots.main.initialData when using CKEditor 5 v48', async () => {
+				vi.stubGlobal( 'CKEDITOR_VERSION', '48.0.0' );
+
+				const localFixture = TestBed.createComponent( CKEditorComponent );
+				const localComponent = localFixture.componentInstance;
+				localComponent.editor = MockEditor as any;
+				localComponent.data = 'foo';
+
+				localFixture.detectChanges();
+
+				await waitCycle();
+
+				expect( ( localComponent.editorInstance as any ).config.roots?.main?.initialData ).toBe( 'foo' );
+				expect( ( localComponent.editorInstance as any ).config.initialData ).toBeUndefined();
+
+				localFixture.destroy();
 			} );
 
 			it( 'should be configurable at the start of the component using the `config.initialData` property', async () => {

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -38,6 +38,7 @@ import type { ControlValueAccessor } from '@angular/forms';
 import { uid } from '@ckeditor/ckeditor5-integrations-common';
 import { appendAllIntegrationPluginsToConfig } from './plugins/append-all-integration-plugins-to-config';
 import { DisabledEditorWatchdog } from './disabled-editor-watchdog';
+import { assignInitialDataToEditorConfig } from './utils/assignInitialDataToEditorConfig';
 
 const ANGULAR_INTEGRATION_READ_ONLY_LOCK_ID = 'Lock from Angular integration (@ckeditor/ckeditor5-angular)';
 
@@ -472,19 +473,7 @@ export class CKEditorComponent<TEditor extends Editor = Editor> implements After
 	}
 
 	private getConfig() {
-		if ( this.data && this.config.initialData ) {
-			throw new Error( 'Editor data should be provided either using `config.initialData` or `data` properties.' );
-		}
-
-		const config = { ...this.config };
-
-		// Merge two possible ways of providing data into the `config.initialData` field.
-		const initialData = this.config.initialData || this.data;
-
-		if ( initialData ) {
-			// Define the `config.initialData` only when the initial content is specified.
-			config.initialData = initialData;
-		}
+		const config = assignInitialDataToEditorConfig( this.config, this.data );
 
 		return appendAllIntegrationPluginsToConfig( config );
 	}

--- a/src/ckeditor/package.json
+++ b/src/ckeditor/package.json
@@ -19,7 +19,7 @@
     "ckeditor 5"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-integrations-common": "^2.2.2"
+    "@ckeditor/ckeditor5-integrations-common": "^2.2.4"
   },
   "peerDependencies": {
     "@angular/core": ">=19.2.19",

--- a/src/ckeditor/utils/assignInitialDataToEditorConfig.spec.ts
+++ b/src/ckeditor/utils/assignInitialDataToEditorConfig.spec.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
 	assignInitialDataToEditorConfig,
@@ -12,49 +12,43 @@ import {
 } from './assignInitialDataToEditorConfig';
 
 describe( 'assignInitialDataToEditorConfig', () => {
-	let originalCKEditorVersion: string | undefined;
-
-	beforeEach( () => {
-		originalCKEditorVersion = ( window as any ).CKEDITOR_VERSION;
-	} );
-
 	afterEach( () => {
-		( window as any ).CKEDITOR_VERSION = originalCKEditorVersion;
+		vi.unstubAllGlobals();
 	} );
 
 	describe( 'isRootsMapConfigurationSupported()', () => {
 		it( 'should return false when CKEDITOR_VERSION is not set', () => {
-			delete ( window as any ).CKEDITOR_VERSION;
+			vi.stubGlobal( 'CKEDITOR_VERSION', undefined );
 
 			expect( isRootsMapConfigurationSupported() ).toBe( false );
 		} );
 
 		it( 'should return false for version 47.x', () => {
-			( window as any ).CKEDITOR_VERSION = '47.0.0';
+			vi.stubGlobal( 'CKEDITOR_VERSION', '47.0.0' );
 
 			expect( isRootsMapConfigurationSupported() ).toBe( false );
 		} );
 
 		it( 'should return false for version below 48', () => {
-			( window as any ).CKEDITOR_VERSION = '47.9.9';
+			vi.stubGlobal( 'CKEDITOR_VERSION', '47.9.9' );
 
 			expect( isRootsMapConfigurationSupported() ).toBe( false );
 		} );
 
 		it( 'should return true for version 48.0.0', () => {
-			( window as any ).CKEDITOR_VERSION = '48.0.0';
+			vi.stubGlobal( 'CKEDITOR_VERSION', '48.0.0' );
 
 			expect( isRootsMapConfigurationSupported() ).toBe( true );
 		} );
 
 		it( 'should return true for versions above 48', () => {
-			( window as any ).CKEDITOR_VERSION = '50.3.1';
+			vi.stubGlobal( 'CKEDITOR_VERSION', '50.3.1' );
 
 			expect( isRootsMapConfigurationSupported() ).toBe( true );
 		} );
 
 		it( 'should return true for non-semantic (nightly/internal) versions', () => {
-			( window as any ).CKEDITOR_VERSION = 'nightly';
+			vi.stubGlobal( 'CKEDITOR_VERSION', 'nightly' );
 
 			expect( isRootsMapConfigurationSupported() ).toBe( true );
 		} );
@@ -62,7 +56,7 @@ describe( 'assignInitialDataToEditorConfig', () => {
 
 	describe( 'legacy path (CKEditor 47.x)', () => {
 		beforeEach( () => {
-			( window as any ).CKEDITOR_VERSION = '47.0.0';
+			vi.stubGlobal( 'CKEDITOR_VERSION', '47.0.0' );
 		} );
 
 		it( 'should assign data to initialData field', () => {
@@ -106,7 +100,7 @@ describe( 'assignInitialDataToEditorConfig', () => {
 
 	describe( 'roots-map path (CKEditor 48.x+)', () => {
 		beforeEach( () => {
-			( window as any ).CKEDITOR_VERSION = '48.0.0';
+			vi.stubGlobal( 'CKEDITOR_VERSION', '48.0.0' );
 		} );
 
 		it( 'should assign data to roots.main.initialData', () => {
@@ -177,7 +171,7 @@ describe( 'assignInitialDataToEditorConfig', () => {
 	describe( 'getInitialDataFromEditorConfig()', () => {
 		describe( 'legacy path (CKEditor 47.x)', () => {
 			beforeEach( () => {
-				( window as any ).CKEDITOR_VERSION = '47.0.0';
+				vi.stubGlobal( 'CKEDITOR_VERSION', '47.0.0' );
 			} );
 
 			it( 'should return config.initialData', () => {
@@ -191,7 +185,7 @@ describe( 'assignInitialDataToEditorConfig', () => {
 
 		describe( 'roots-map path (CKEditor 48.x+)', () => {
 			beforeEach( () => {
-				( window as any ).CKEDITOR_VERSION = '48.0.0';
+				vi.stubGlobal( 'CKEDITOR_VERSION', '48.0.0' );
 			} );
 
 			it( 'should return roots.main.initialData', () => {

--- a/src/ckeditor/utils/assignInitialDataToEditorConfig.spec.ts
+++ b/src/ckeditor/utils/assignInitialDataToEditorConfig.spec.ts
@@ -178,6 +178,12 @@ describe( 'assignInitialDataToEditorConfig', () => {
 
 			expect( result.roots.secondary ).toMatchObject( { initialData: 'secondary data' } );
 		} );
+
+		it( 'should set roots.main.initialData to empty string when neither data nor config initialData is provided', () => {
+			const result = assignInitialDataToEditorConfig( {}, '' ) as any;
+
+			expect( result.roots.main.initialData ).toBe( '' );
+		} );
 	} );
 
 	describe( 'getInitialDataFromEditorConfig()', () => {

--- a/src/ckeditor/utils/assignInitialDataToEditorConfig.spec.ts
+++ b/src/ckeditor/utils/assignInitialDataToEditorConfig.spec.ts
@@ -121,7 +121,7 @@ describe( 'assignInitialDataToEditorConfig', () => {
 			} );
 		} );
 
-		it( 'should merge with existing config.roots.main, with data taking precedence', () => {
+		it( 'should merge with existing config.roots.main, with config taking precedence', () => {
 			const result = assignInitialDataToEditorConfig(
 				{ roots: { main: { initialData: 'old', someOption: 42 } } },
 				'new'
@@ -129,7 +129,19 @@ describe( 'assignInitialDataToEditorConfig', () => {
 
 			expect( result.roots.main ).toMatchObject( {
 				someOption: 42,
-				initialData: 'new'
+				initialData: 'old'
+			} );
+		} );
+
+		it( 'should merge with existing config.root, with config taking precedence', () => {
+			const result = assignInitialDataToEditorConfig(
+				{ root: { initialData: 'old', someRootOption: true } },
+				'new'
+			) as any;
+
+			expect( result.roots.main ).toMatchObject( {
+				someRootOption: true,
+				initialData: 'old'
 			} );
 		} );
 

--- a/src/ckeditor/utils/assignInitialDataToEditorConfig.spec.ts
+++ b/src/ckeditor/utils/assignInitialDataToEditorConfig.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+	assignInitialDataToEditorConfig,
+	getInitialDataFromEditorConfig,
+	isRootsMapConfigurationSupported
+} from './assignInitialDataToEditorConfig';
+
+describe( 'assignInitialDataToEditorConfig', () => {
+	let originalCKEditorVersion: string | undefined;
+
+	beforeEach( () => {
+		originalCKEditorVersion = ( window as any ).CKEDITOR_VERSION;
+	} );
+
+	afterEach( () => {
+		( window as any ).CKEDITOR_VERSION = originalCKEditorVersion;
+	} );
+
+	describe( 'isRootsMapConfigurationSupported()', () => {
+		it( 'should return false when CKEDITOR_VERSION is not set', () => {
+			delete ( window as any ).CKEDITOR_VERSION;
+
+			expect( isRootsMapConfigurationSupported() ).toBe( false );
+		} );
+
+		it( 'should return false for version 47.x', () => {
+			( window as any ).CKEDITOR_VERSION = '47.0.0';
+
+			expect( isRootsMapConfigurationSupported() ).toBe( false );
+		} );
+
+		it( 'should return false for version below 48', () => {
+			( window as any ).CKEDITOR_VERSION = '47.9.9';
+
+			expect( isRootsMapConfigurationSupported() ).toBe( false );
+		} );
+
+		it( 'should return true for version 48.0.0', () => {
+			( window as any ).CKEDITOR_VERSION = '48.0.0';
+
+			expect( isRootsMapConfigurationSupported() ).toBe( true );
+		} );
+
+		it( 'should return true for versions above 48', () => {
+			( window as any ).CKEDITOR_VERSION = '50.3.1';
+
+			expect( isRootsMapConfigurationSupported() ).toBe( true );
+		} );
+
+		it( 'should return true for non-semantic (nightly/internal) versions', () => {
+			( window as any ).CKEDITOR_VERSION = 'nightly';
+
+			expect( isRootsMapConfigurationSupported() ).toBe( true );
+		} );
+	} );
+
+	describe( 'legacy path (CKEditor 47.x)', () => {
+		beforeEach( () => {
+			( window as any ).CKEDITOR_VERSION = '47.0.0';
+		} );
+
+		it( 'should assign data to initialData field', () => {
+			const result = assignInitialDataToEditorConfig( {}, 'hello' );
+
+			expect( result ).toMatchObject( { initialData: 'hello' } );
+		} );
+
+		it( 'should preserve existing config fields', () => {
+			const result = assignInitialDataToEditorConfig( { toolbar: [ 'bold' ] }, 'hello' );
+
+			expect( result ).toMatchObject( { toolbar: [ 'bold' ], initialData: 'hello' } );
+		} );
+
+		it( 'should use config.initialData when data is empty', () => {
+			const result = assignInitialDataToEditorConfig( { initialData: 'from config' }, '' );
+
+			expect( result ).toMatchObject( { initialData: 'from config' } );
+		} );
+
+		it( 'should set initialData to empty string when neither data nor config.initialData is provided', () => {
+			const result = assignInitialDataToEditorConfig( {}, '' );
+
+			expect( result ).toMatchObject( { initialData: '' } );
+		} );
+
+		it( 'should throw when both data and config.initialData are provided', () => {
+			expect( () => {
+				assignInitialDataToEditorConfig( { initialData: 'from config' }, 'from prop' );
+			} ).toThrow(
+				'Editor data should be provided either using `config.initialData` or `data` properties.'
+			);
+		} );
+
+		it( 'should not add roots field to the result', () => {
+			const result = assignInitialDataToEditorConfig( {}, 'hello' ) as any;
+
+			expect( result.roots ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'roots-map path (CKEditor 48.x+)', () => {
+		beforeEach( () => {
+			( window as any ).CKEDITOR_VERSION = '48.0.0';
+		} );
+
+		it( 'should assign data to roots.main.initialData', () => {
+			const result = assignInitialDataToEditorConfig( {}, 'hello' ) as any;
+
+			expect( result.roots?.main?.initialData ).toBe( 'hello' );
+		} );
+
+		it( 'should preserve existing config.root properties under roots.main', () => {
+			const result = assignInitialDataToEditorConfig(
+				{ root: { someRootOption: true } },
+				'hello'
+			) as any;
+
+			expect( result.roots.main ).toMatchObject( {
+				someRootOption: true,
+				initialData: 'hello'
+			} );
+		} );
+
+		it( 'should merge with existing config.roots.main, with data taking precedence', () => {
+			const result = assignInitialDataToEditorConfig(
+				{ roots: { main: { initialData: 'old', someOption: 42 } } },
+				'new'
+			) as any;
+
+			expect( result.roots.main ).toMatchObject( {
+				someOption: 42,
+				initialData: 'new'
+			} );
+		} );
+
+		it( 'should remove root and initialData top-level fields from the result', () => {
+			const result = assignInitialDataToEditorConfig(
+				{ root: { someRootOption: true }, initialData: 'ignored' },
+				'hello'
+			) as any;
+
+			expect( result.root ).toBeUndefined();
+			expect( result.initialData ).toBeUndefined();
+		} );
+
+		it( 'should preserve other top-level config fields', () => {
+			const result = assignInitialDataToEditorConfig(
+				{ toolbar: [ 'bold' ] },
+				'hello'
+			) as any;
+
+			expect( result.toolbar ).toEqual( [ 'bold' ] );
+		} );
+
+		it( 'should not throw when both data and config.initialData are provided', () => {
+			expect( () => {
+				assignInitialDataToEditorConfig( { initialData: 'ignored' }, 'hello' );
+			} ).not.toThrow();
+		} );
+
+		it( 'should preserve non-main roots', () => {
+			const result = assignInitialDataToEditorConfig(
+				{ roots: { secondary: { initialData: 'secondary data' } } },
+				'hello'
+			) as any;
+
+			expect( result.roots.secondary ).toMatchObject( { initialData: 'secondary data' } );
+		} );
+	} );
+
+	describe( 'getInitialDataFromEditorConfig()', () => {
+		describe( 'legacy path (CKEditor 47.x)', () => {
+			beforeEach( () => {
+				( window as any ).CKEDITOR_VERSION = '47.0.0';
+			} );
+
+			it( 'should return config.initialData', () => {
+				expect( getInitialDataFromEditorConfig( { initialData: 'hello' } ) ).toBe( 'hello' );
+			} );
+
+			it( 'should return undefined when config.initialData is absent', () => {
+				expect( getInitialDataFromEditorConfig( {} ) ).toBeUndefined();
+			} );
+		} );
+
+		describe( 'roots-map path (CKEditor 48.x+)', () => {
+			beforeEach( () => {
+				( window as any ).CKEDITOR_VERSION = '48.0.0';
+			} );
+
+			it( 'should return roots.main.initialData', () => {
+				expect(
+					getInitialDataFromEditorConfig( { roots: { main: { initialData: 'hello' } } } )
+				).toBe( 'hello' );
+			} );
+
+			it( 'should return undefined when roots.main is absent', () => {
+				expect( getInitialDataFromEditorConfig( {} ) ).toBeUndefined();
+			} );
+
+			it( 'should return undefined when roots.main.initialData is absent', () => {
+				expect( getInitialDataFromEditorConfig( { roots: { main: {} } } ) ).toBeUndefined();
+			} );
+		} );
+	} );
+} );

--- a/src/ckeditor/utils/assignInitialDataToEditorConfig.ts
+++ b/src/ckeditor/utils/assignInitialDataToEditorConfig.ts
@@ -27,6 +27,12 @@ import {
  */
 export function assignInitialDataToEditorConfig( config: Record<string, any>, data: string ): EditorConfig {
 	if ( isRootsMapConfigurationSupported() ) {
+		// For >= 48.x versions, the `data` property should be assigned to `root.initialData` field in the configuration object.
+		const configInitialData =
+			config.roots?.main?.initialData ||
+			config.root?.initialData ||
+			/* legacy */ config.initialData;
+
 		const normalizedConfig: any = {
 			...config,
 			roots: {
@@ -34,7 +40,7 @@ export function assignInitialDataToEditorConfig( config: Record<string, any>, da
 				main: {
 					...config.root,
 					...config.roots?.main,
-					initialData: data
+					initialData: configInitialData || data || ''
 				}
 			}
 		};
@@ -45,6 +51,7 @@ export function assignInitialDataToEditorConfig( config: Record<string, any>, da
 		return normalizedConfig as unknown as EditorConfig;
 	}
 
+	// Fallback for <= 47.x versions which do not support per-root configuration and use `initialData` field.
 	const configInitialData = config.initialData;
 
 	if ( data && configInitialData ) {

--- a/src/ckeditor/utils/assignInitialDataToEditorConfig.ts
+++ b/src/ckeditor/utils/assignInitialDataToEditorConfig.ts
@@ -1,0 +1,93 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import type { EditorConfig } from 'ckeditor5';
+
+import {
+	destructureSemanticVersion,
+	getCKBaseBundleInstallationInfo,
+	isSemanticVersion
+} from '@ckeditor/ckeditor5-integrations-common';
+
+/**
+ * Assigns the `data` property to the correct field in the editor configuration object, depending on the loaded CKEditor version.
+ *
+ * At this moment, CKEditor 5 might be loaded in two different versions:
+ *
+ * 1. LTS-one 47.x - It supports both `initialData` and does not support `root.initialData`. It means
+ *    that the `data` property should be assigned to `initialData` field in the configuration object.
+ *
+ * 2. Latest 48.x and newer - It supports `root.initialData` and deprecates `initialData` (which'll be removed in the future).
+ *    It means that the `data` property should be assigned to `root.initialData` field in the configuration object.
+ *
+ * @param config The editor configuration.
+ * @param data The editor data. It is used to log warnings when both `data` and `initialData` are specified.
+ */
+export function assignInitialDataToEditorConfig( config: Record<string, any>, data: string ): EditorConfig {
+	if ( isRootsMapConfigurationSupported() ) {
+		const normalizedConfig: any = {
+			...config,
+			roots: {
+				...config.roots,
+				main: {
+					...config.root,
+					...config.roots?.main,
+					initialData: data
+				}
+			}
+		};
+
+		delete normalizedConfig.root;
+		delete normalizedConfig.initialData;
+
+		return normalizedConfig as unknown as EditorConfig;
+	}
+
+	const configInitialData = config.initialData;
+
+	if ( data && configInitialData ) {
+		throw new Error( 'Editor data should be provided either using `config.initialData` or `data` properties.' );
+	}
+
+	return {
+		...config,
+		initialData: configInitialData || data || ''
+	} as unknown as EditorConfig;
+}
+
+/**
+ * Retrieves the initial data from the editor configuration object, depending on the loaded CKEditor version.
+ */
+export function getInitialDataFromEditorConfig( config: Record<string, any> ): string | undefined {
+	if ( isRootsMapConfigurationSupported() ) {
+		return config.roots?.main?.initialData;
+	}
+
+	return config.initialData;
+}
+
+/**
+ * Retrieve information about the base CKEditor bundle installation and checks if it supports per-root configuration.
+ * It may return `null` if the editor is not loaded yet, or something else removed global editor versions variable.
+ * In such case, we will assume that the loaded CKEditor version is compatible with all newest features
+ * and use `root.initialData` field.
+ *
+ * @returns `true` if the loaded CKEditor version supports per-root configuration, `false` otherwise.
+ */
+export function isRootsMapConfigurationSupported(): boolean {
+	const bundleInfo = getCKBaseBundleInstallationInfo();
+
+	if ( !bundleInfo ) {
+		return false;
+	}
+
+	// If it's nightly, internal, or any other version, assume it's compatible with all newest features.
+	// Versions >= 48 prefer to use `root.initialData` instead of `initialData` field, so we need to normalize
+	// the configuration object to make it work with all versions.
+	return (
+		!isSemanticVersion( bundleInfo.version ) ||
+		destructureSemanticVersion( bundleInfo.version ).major >= 48
+	);
+}

--- a/src/ckeditor/utils/assignInitialDataToEditorConfig.ts
+++ b/src/ckeditor/utils/assignInitialDataToEditorConfig.ts
@@ -71,8 +71,6 @@ export function getInitialDataFromEditorConfig( config: Record<string, any> ): s
 /**
  * Retrieve information about the base CKEditor bundle installation and checks if it supports per-root configuration.
  * It may return `null` if the editor is not loaded yet, or something else removed global editor versions variable.
- * In such case, we will assume that the loaded CKEditor version is compatible with all newest features
- * and use `root.initialData` field.
  *
  * @returns `true` if the loaded CKEditor version supports per-root configuration, `false` otherwise.
  */


### PR DESCRIPTION
### 🚀 Summary

Add support for CKEditor 48.x data config format

---

### 📌 Related issues

* Closes #547 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how initial editor data is mapped into the editor config based on detected CKEditor version (switching to `config.roots.main.initialData` for 48+), which could affect initialization behavior in existing integrations despite added test coverage.
> 
> **Overview**
> Adds CKEditor 5 `48.x` compatibility by **version-switching initial data configuration**: for 48+ it normalizes configs to use `roots.main.initialData` (and merges legacy `root`/`initialData` into `roots`), while keeping the `initialData` path for 47.x.
> 
> Updates unit tests to cover both config formats and bumps `@ckeditor/ckeditor5-integrations-common` to `^2.2.4`, plus a changelog entry closing #547.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2be0f5458a1a7da8f32f71d69e79a6122ea2842c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->