### PR TITLE
Remove the notify_ci_failure job from the CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,9 @@ commands:
           command: sudo corepack disable
       - run:
           name: Install pnpm
-          command: sudo npm i -g pnpm@^11
+          # Pinned to ~11.14.0; pnpm 11.15.x duplicates the CKEditor packages in the
+          # LTS integration run, which breaks the editor.
+          command: sudo npm i -g pnpm@~11.14.0
       - run:
           name: Install dependencies
           command: pnpm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,33 +68,6 @@ commands:
             git config --global tag.gpgSign true
 
 jobs:
-  notify_ci_failure:
-    docker:
-      - image: cimg/node:24.11.0
-    resource_class: small
-    parameters:
-      hideAuthor:
-        type: string
-        default: "false"
-    steps:
-      - checkout
-      - bootstrap_repository_command
-      - run:
-          # In the PRs that comes from forked repositories, we do not share secret variables.
-          # Hence, some of the scripts will not be executed.
-          name: 👤 Verify if the build was triggered by community - Check if the build should continue
-          command: |
-            #!/bin/bash
-
-            if [[ -z ${CODECOV_TOKEN} ]];
-            then
-              circleci-agent step halt
-            fi
-      - run:
-          name: Waiting for other jobs to finish and sending notification on failure
-          command: pnpm ckeditor5-dev-ci-circle-workflow-notifier --task "pnpm ckeditor5-dev-ci-notify-circle-status --pipeline-id << pipeline.number >> --hide-author << parameters.hideAuthor >>"
-          no_output_timeout: 1h
-
   validate:
     docker:
       - image: cimg/node:24.11.0
@@ -307,11 +280,6 @@ workflows:
             branches:
               only:
                 - master
-      - notify_ci_failure:
-          filters:
-            branches:
-              only:
-                - master
 
   release:
     when:
@@ -337,9 +305,3 @@ workflows:
           matrix:
             parameters:
               ckeditorDistTag: *integration_editor_version_tags
-      - notify_ci_failure:
-          hideAuthor: "true"
-          filters:
-            branches:
-              only:
-                - master


### PR DESCRIPTION
### 🚀 Summary

CI failure notifications for this repository are now sent by DevHub. DevHub listens to the CircleCI `workflow-completed` webhook and posts the failure message to Slack. The `notify_ci_failure` job that polled the workflow status is no longer needed, so this PR removes it from the CircleCI configuration.

This PR is internal-only (CI configuration), so it does not add a changelog entry.

---

### 📌 Related issues

* See https://github.com/cksource/ckeditor5-devhub/issues/424.
---

### 💡 Additional information

The removed parts are:

* The `notify_ci_failure` job definition, together with its `hideAuthor` parameter.
* The `notify_ci_failure` usages in the `main` and `nightly` workflows.

The shared commands (for example `bootstrap_repository_command`) stay in place because other jobs still use them. The diff contains only deletions.

